### PR TITLE
Update datalab_create.sh

### DIFF
--- a/ml/cc/bin/datalab_create.sh
+++ b/ml/cc/bin/datalab_create.sh
@@ -11,8 +11,8 @@ set -e
 prompt_user_for_confirmation "Google Compute Engine and Cloud Machine Learning APIs will be enabled and new Datalab VM will be created."
 
 echo "Enabling Google Compute Engine and Cloud Machine Learning APIs"
-gcloud service-management enable compute_component
-gcloud service-management enable ml.googleapis.com
+gcloud services enable compute_component
+gcloud services enable ml.googleapis.com
 
 assert_datalab_vm_does_not_exist
 


### PR DESCRIPTION
According [the instruction](https://cloud.google.com/sdk/gcloud/reference/service-management/enable) of Google Cloud Platform SDK, the gcloud service-management  command has deprecated, and replaced by gcloud services command.