### PR TITLE
Remove redundant call to train_linear_classifier_model

### DIFF
--- a/ml/cc/exercises/logistic_regression.ipynb
+++ b/ml/cc/exercises/logistic_regression.ipynb
@@ -653,16 +653,7 @@
         "  plt.plot(validation_log_losses, label=\"validation\")\n",
         "  plt.legend()\n",
         "\n",
-        "  return linear_classifier\n",
-        "\n",
-        "linear_classifier = train_linear_classifier_model(\n",
-        "    learning_rate=0.000005,\n",
-        "    steps=500,\n",
-        "    batch_size=20,\n",
-        "    training_examples=training_examples,\n",
-        "    training_targets=training_targets,\n",
-        "    validation_examples=validation_examples,\n",
-        "    validation_targets=validation_targets)"
+        "  return linear_classifier\n"
       ],
       "cell_type": "code",
       "execution_count": 0,


### PR DESCRIPTION
The instructions have two calls to `train_linear_classifier_model`: one in the cell where it is defined, and one in the following cell. This is redundant, and to be consistent with the rest of the instructions the calling cell should be separate from the defining cell.