### PR TITLE
Remove duplicated linear classifier training code

### DIFF
--- a/ml/cc/exercises/logistic_regression.ipynb
+++ b/ml/cc/exercises/logistic_regression.ipynb
@@ -655,16 +655,7 @@
         "  plt.plot(validation_log_losses, label=\"validation\")\n",
         "  plt.legend()\n",
         "\n",
-        "  return linear_classifier\n",
-        "\n",
-        "linear_classifier = train_linear_classifier_model(\n",
-        "    learning_rate=0.000005,\n",
-        "    steps=500,\n",
-        "    batch_size=20,\n",
-        "    training_examples=training_examples,\n",
-        "    training_targets=training_targets,\n",
-        "    validation_examples=validation_examples,\n",
-        "    validation_targets=validation_targets)"
+        "  return linear_classifier\n"
       ],
       "cell_type": "code",
       "execution_count": 0,


### PR DESCRIPTION
The call to `train_linear_classifier_model` appeared at the end of the cell defining that function, and again in the cell immediately after, with identical hyperparameters. For consistency with the rest of the course, I removed the function call at the end of the cell with the definition.