### PR TITLE
Style update first_steps_with_tensor_flow.ipynb

### DIFF
--- a/ml/cc/exercises/first_steps_with_tensor_flow.ipynb
+++ b/ml/cc/exercises/first_steps_with_tensor_flow.ipynb
@@ -526,10 +526,10 @@
         }
       },
       "source": [
-        "_ = linear_regressor.train(\n",
+        "linear_regressor.train(\n",
         "    input_fn = lambda:my_input_fn(my_feature, targets),\n",
         "    steps=100\n",
-        ")"
+        ");"
       ],
       "cell_type": "code",
       "execution_count": 0,


### PR DESCRIPTION
With Jupyter notebook the preferred way to supress output is with a ';' at the end (not assigning '_'). https://ipython.readthedocs.io/en/stable/interactive/tips.html?#suppress-output
The underscore variable will be assigned automatically so no need to do that as well.