### PR TITLE
Fix regularization strength required to achieve model size

### DIFF
--- a/ml/cc/exercises/sparsity_and_l1_regularization.ipynb
+++ b/ml/cc/exercises/sparsity_and_l1_regularization.ipynb
@@ -1,46 +1,25 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "sparsity_and_l1_regularization.ipynb",
-      "version": "0.3.2",
-      "views": {},
-      "default_view": {},
-      "provenance": [],
-      "collapsed_sections": [
-        "JndnmDMp66FL",
-        "yjUCX5LAkxAX"
-      ]
-    },
-    "kernelspec": {
-      "name": "python2",
-      "display_name": "Python 2"
-    }
-  },
   "cells": [
     {
+      "cell_type": "markdown",
       "metadata": {
-        "id": "JndnmDMp66FL",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "JndnmDMp66FL"
       },
       "source": [
         "#### Copyright 2017 Google LLC."
-      ],
-      "cell_type": "markdown"
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "hMqWDc_m6rUC",
+        "cellView": "both",
+        "colab": {},
         "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        },
-        "cellView": "both"
+        "id": "hMqWDc_m6rUC"
       },
+      "outputs": [],
       "source": [
         "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -53,69 +32,64 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ],
-      "cell_type": "code",
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
-        "id": "g4T-_IsVbweU",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "g4T-_IsVbweU"
       },
       "source": [
         "# Sparsity and L1 Regularization"
-      ],
-      "cell_type": "markdown"
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
-        "id": "g8ue2FyFIjnQ",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "g8ue2FyFIjnQ"
       },
       "source": [
         "**Learning Objectives:**\n",
         "  * Calculate the size of a model\n",
         "  * Apply L1 regularization to reduce the size of a model by increasing sparsity"
-      ],
-      "cell_type": "markdown"
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
-        "id": "ME_WXE7cIjnS",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "ME_WXE7cIjnS"
       },
       "source": [
         "One way to reduce complexity is to use a regularization function that encourages weights to be exactly zero. For linear models such as regression, a zero weight is equivalent to not using the corresponding feature at all. In addition to avoiding overfitting, the resulting model will be more efficient.\n",
         "\n",
         "L1 regularization is a good way to increase sparsity.\n",
         "\n"
-      ],
-      "cell_type": "markdown"
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
-        "id": "fHRzeWkRLrHF",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "fHRzeWkRLrHF"
       },
       "source": [
         "## Setup\n",
         "\n",
         "Run the cells below to load the data and create feature definitions."
-      ],
-      "cell_type": "markdown"
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "pb7rSrLKIjnS",
+        "colab": {},
         "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        }
+        "id": "pb7rSrLKIjnS"
       },
+      "outputs": [],
       "source": [
         "from __future__ import print_function\n",
         "\n",
@@ -139,22 +113,17 @@
         "\n",
         "california_housing_dataframe = california_housing_dataframe.reindex(\n",
         "    np.random.permutation(california_housing_dataframe.index))"
-      ],
-      "cell_type": "code",
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "3V7q8jk0IjnW",
+        "colab": {},
         "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        }
+        "id": "3V7q8jk0IjnW"
       },
+      "outputs": [],
       "source": [
         "def preprocess_features(california_housing_dataframe):\n",
         "  \"\"\"Prepares input features from California housing data set.\n",
@@ -195,24 +164,19 @@
         "  # Create a boolean categorical feature representing whether the\n",
         "  # median_house_value is above a set threshold.\n",
         "  output_targets[\"median_house_value_is_high\"] = (\n",
-        "    california_housing_dataframe[\"median_house_value\"] > 265000).astype(float)\n",
+        "    california_housing_dataframe[\"median_house_value\"] \u003e 265000).astype(float)\n",
         "  return output_targets"
-      ],
-      "cell_type": "code",
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "pAG3tmgwIjnY",
+        "colab": {},
         "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        }
+        "id": "pAG3tmgwIjnY"
       },
+      "outputs": [],
       "source": [
         "# Choose the first 12000 (out of 17000) examples for training.\n",
         "training_examples = preprocess_features(california_housing_dataframe.head(12000))\n",
@@ -232,22 +196,17 @@
         "display.display(training_targets.describe())\n",
         "print(\"Validation targets summary:\")\n",
         "display.display(validation_targets.describe())"
-      ],
-      "cell_type": "code",
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "gHkniRI1Ijna",
+        "colab": {},
         "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        }
+        "id": "gHkniRI1Ijna"
       },
+      "outputs": [],
       "source": [
         "def my_input_fn(features, targets, batch_size=1, shuffle=True, num_epochs=None):\n",
         "    \"\"\"Trains a linear regression model.\n",
@@ -276,43 +235,33 @@
         "    # Return the next batch of data.\n",
         "    features, labels = ds.make_one_shot_iterator().get_next()\n",
         "    return features, labels"
-      ],
-      "cell_type": "code",
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "bLzK72jkNJPf",
+        "colab": {},
         "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        }
+        "id": "bLzK72jkNJPf"
       },
+      "outputs": [],
       "source": [
         "def get_quantile_based_buckets(feature_values, num_buckets):\n",
         "  quantiles = feature_values.quantile(\n",
         "    [(i+1.)/(num_buckets + 1.) for i in range(num_buckets)])\n",
         "  return [quantiles[q] for q in quantiles.keys()]"
-      ],
-      "cell_type": "code",
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "al2YQpKyIjnd",
+        "colab": {},
         "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        }
+        "id": "al2YQpKyIjnd"
       },
+      "outputs": [],
       "source": [
         "def construct_feature_columns():\n",
         "  \"\"\"Construct the TensorFlow Feature Columns.\n",
@@ -367,34 +316,29 @@
         "    bucketized_rooms_per_person])\n",
         "  \n",
         "  return feature_columns"
-      ],
-      "cell_type": "code",
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
-        "id": "hSBwMrsrE21n",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "hSBwMrsrE21n"
       },
       "source": [
         "## Calculate the Model Size\n",
         "\n",
         "To calculate the model size, we simply count the number of parameters that are non-zero. We provide a helper function below to do that. The function uses intimate knowledge of the Estimators API - don't worry about understanding how it works."
-      ],
-      "cell_type": "markdown"
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "e6GfTI0CFhB8",
+        "colab": {},
         "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        }
+        "id": "e6GfTI0CFhB8"
       },
+      "outputs": [],
       "source": [
         "def model_size(estimator):\n",
         "  variables = estimator.get_variable_names()\n",
@@ -408,15 +352,13 @@
         "              ):\n",
         "      size += np.count_nonzero(estimator.get_variable_value(variable))\n",
         "  return size"
-      ],
-      "cell_type": "code",
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
-        "id": "XabdAaj67GfF",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "XabdAaj67GfF"
       },
       "source": [
         "## Reduce the Model Size\n",
@@ -426,13 +368,13 @@
         "Since the SmartRing is small, the engineering team has determined that it can only handle a model that has **no more than 600 parameters**. On the other hand, the product management team has determined that the model is not launchable unless the **LogLoss is less than 0.35** on the holdout test set.\n",
         "\n",
         "Can you use your secret weapon—L1 regularization—to tune the model to satisfy both the size and accuracy constraints?"
-      ],
-      "cell_type": "markdown"
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
-        "id": "G79hGRe7qqej",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "G79hGRe7qqej"
       },
       "source": [
         "### Task 1: Find a good regularization coefficient.\n",
@@ -442,20 +384,17 @@
         "The following code will help you get started. There are many ways to apply regularization to your model. Here, we chose to do it using `FtrlOptimizer`, which is designed to give better results with L1 regularization than standard gradient descent.\n",
         "\n",
         "Again, the model will train on the entire data set, so expect it to run slower than normal."
-      ],
-      "cell_type": "markdown"
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "1Fcdm0hpIjnl",
+        "colab": {},
         "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        }
+        "id": "1Fcdm0hpIjnl"
       },
+      "outputs": [],
       "source": [
         "def train_linear_classifier_model(\n",
         "    learning_rate,\n",
@@ -555,22 +494,17 @@
         "  plt.legend()\n",
         "\n",
         "  return linear_classifier"
-      ],
-      "cell_type": "code",
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "9H1CKHSzIjno",
+        "colab": {},
         "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        }
+        "id": "9H1CKHSzIjno"
       },
+      "outputs": [],
       "source": [
         "linear_classifier = train_linear_classifier_model(\n",
         "    learning_rate=0.1,\n",
@@ -584,49 +518,43 @@
         "    validation_examples=validation_examples,\n",
         "    validation_targets=validation_targets)\n",
         "print(\"Model size:\", model_size(linear_classifier))"
-      ],
-      "cell_type": "code",
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
-        "id": "yjUCX5LAkxAX",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "yjUCX5LAkxAX"
       },
       "source": [
         "### Solution\n",
         "\n",
         "Click below to see a possible solution."
-      ],
-      "cell_type": "markdown"
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
-        "id": "hgGhy-okmkWL",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "hgGhy-okmkWL"
       },
       "source": [
-        "A regularization strength of 0.7 should be sufficient. Note that there is a compromise to be struck:\n",
-        "stronger regularization gives us smaller models, but can affect the classification loss."
-      ],
-      "cell_type": "markdown"
+        "Because you're reducing model size while training on a toy dataset, you're forced to raise regularization strength to `0.8`, which is anomalously high. When training on real-world datasets, regularization strength is much smaller than `0.8`. Note that you're trading off model size versus loss. As you decrease model size by increasing regularization, your loss can increase."
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "_rV8YQWZIjns",
+        "colab": {},
         "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        }
+        "id": "_rV8YQWZIjns"
       },
+      "outputs": [],
       "source": [
         "linear_classifier = train_linear_classifier_model(\n",
         "    learning_rate=0.1,\n",
-        "    regularization_strength=0.7,\n",
+        "    regularization_strength=0.8,\n",
         "    steps=300,\n",
         "    batch_size=100,\n",
         "    feature_columns=construct_feature_columns(),\n",
@@ -635,10 +563,23 @@
         "    validation_examples=validation_examples,\n",
         "    validation_targets=validation_targets)\n",
         "print(\"Model size:\", model_size(linear_classifier))"
-      ],
-      "cell_type": "code",
-      "execution_count": 0,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [
+        "JndnmDMp66FL"
+      ],
+      "name": "sparsity_and_l1_regularization.ipynb",
+      "provenance": [],
+      "version": "0.3.2"
+    },
+    "kernelspec": {
+      "display_name": "Python 2",
+      "name": "python2"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/ml/cc/exercises/sparsity_and_l1_regularization.ipynb
+++ b/ml/cc/exercises/sparsity_and_l1_regularization.ipynb
@@ -607,7 +607,7 @@
         "colab_type": "text"
       },
       "source": [
-        "A regularization strength of 0.1 should be sufficient. Note that there is a compromise to be struck:\n",
+        "A regularization strength of 0.7 should be sufficient. Note that there is a compromise to be struck:\n",
         "stronger regularization gives us smaller models, but can affect the classification loss."
       ],
       "cell_type": "markdown"
@@ -626,7 +626,7 @@
       "source": [
         "linear_classifier = train_linear_classifier_model(\n",
         "    learning_rate=0.1,\n",
-        "    regularization_strength=0.1,\n",
+        "    regularization_strength=0.7,\n",
         "    steps=300,\n",
         "    batch_size=100,\n",
         "    feature_columns=construct_feature_columns(),\n",

--- a/ml/cc/exercises/sparsity_and_l1_regularization.ipynb
+++ b/ml/cc/exercises/sparsity_and_l1_regularization.ipynb
@@ -1,25 +1,46 @@
 {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "sparsity_and_l1_regularization.ipynb",
+      "version": "0.3.2",
+      "views": {},
+      "default_view": {},
+      "provenance": [],
+      "collapsed_sections": [
+        "JndnmDMp66FL",
+        "yjUCX5LAkxAX"
+      ]
+    },
+    "kernelspec": {
+      "name": "python2",
+      "display_name": "Python 2"
+    }
+  },
   "cells": [
     {
-      "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "JndnmDMp66FL"
+        "id": "JndnmDMp66FL",
+        "colab_type": "text"
       },
       "source": [
         "#### Copyright 2017 Google LLC."
-      ]
+      ],
+      "cell_type": "markdown"
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "cellView": "both",
-        "colab": {},
+        "id": "hMqWDc_m6rUC",
         "colab_type": "code",
-        "id": "hMqWDc_m6rUC"
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        },
+        "cellView": "both"
       },
-      "outputs": [],
       "source": [
         "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -32,64 +53,69 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ]
+      ],
+      "cell_type": "code",
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "g4T-_IsVbweU"
+        "id": "g4T-_IsVbweU",
+        "colab_type": "text"
       },
       "source": [
         "# Sparsity and L1 Regularization"
-      ]
+      ],
+      "cell_type": "markdown"
     },
     {
-      "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "g8ue2FyFIjnQ"
+        "id": "g8ue2FyFIjnQ",
+        "colab_type": "text"
       },
       "source": [
         "**Learning Objectives:**\n",
         "  * Calculate the size of a model\n",
         "  * Apply L1 regularization to reduce the size of a model by increasing sparsity"
-      ]
+      ],
+      "cell_type": "markdown"
     },
     {
-      "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "ME_WXE7cIjnS"
+        "id": "ME_WXE7cIjnS",
+        "colab_type": "text"
       },
       "source": [
         "One way to reduce complexity is to use a regularization function that encourages weights to be exactly zero. For linear models such as regression, a zero weight is equivalent to not using the corresponding feature at all. In addition to avoiding overfitting, the resulting model will be more efficient.\n",
         "\n",
         "L1 regularization is a good way to increase sparsity.\n",
         "\n"
-      ]
+      ],
+      "cell_type": "markdown"
     },
     {
-      "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "fHRzeWkRLrHF"
+        "id": "fHRzeWkRLrHF",
+        "colab_type": "text"
       },
       "source": [
         "## Setup\n",
         "\n",
         "Run the cells below to load the data and create feature definitions."
-      ]
+      ],
+      "cell_type": "markdown"
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
+        "id": "pb7rSrLKIjnS",
         "colab_type": "code",
-        "id": "pb7rSrLKIjnS"
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
       },
-      "outputs": [],
       "source": [
         "from __future__ import print_function\n",
         "\n",
@@ -113,17 +139,22 @@
         "\n",
         "california_housing_dataframe = california_housing_dataframe.reindex(\n",
         "    np.random.permutation(california_housing_dataframe.index))"
-      ]
-    },
-    {
+      ],
       "cell_type": "code",
       "execution_count": 0,
+      "outputs": []
+    },
+    {
       "metadata": {
-        "colab": {},
+        "id": "3V7q8jk0IjnW",
         "colab_type": "code",
-        "id": "3V7q8jk0IjnW"
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
       },
-      "outputs": [],
       "source": [
         "def preprocess_features(california_housing_dataframe):\n",
         "  \"\"\"Prepares input features from California housing data set.\n",
@@ -164,19 +195,24 @@
         "  # Create a boolean categorical feature representing whether the\n",
         "  # median_house_value is above a set threshold.\n",
         "  output_targets[\"median_house_value_is_high\"] = (\n",
-        "    california_housing_dataframe[\"median_house_value\"] \u003e 265000).astype(float)\n",
+        "    california_housing_dataframe[\"median_house_value\"] > 265000).astype(float)\n",
         "  return output_targets"
-      ]
-    },
-    {
+      ],
       "cell_type": "code",
       "execution_count": 0,
+      "outputs": []
+    },
+    {
       "metadata": {
-        "colab": {},
+        "id": "pAG3tmgwIjnY",
         "colab_type": "code",
-        "id": "pAG3tmgwIjnY"
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
       },
-      "outputs": [],
       "source": [
         "# Choose the first 12000 (out of 17000) examples for training.\n",
         "training_examples = preprocess_features(california_housing_dataframe.head(12000))\n",
@@ -196,17 +232,22 @@
         "display.display(training_targets.describe())\n",
         "print(\"Validation targets summary:\")\n",
         "display.display(validation_targets.describe())"
-      ]
-    },
-    {
+      ],
       "cell_type": "code",
       "execution_count": 0,
+      "outputs": []
+    },
+    {
       "metadata": {
-        "colab": {},
+        "id": "gHkniRI1Ijna",
         "colab_type": "code",
-        "id": "gHkniRI1Ijna"
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
       },
-      "outputs": [],
       "source": [
         "def my_input_fn(features, targets, batch_size=1, shuffle=True, num_epochs=None):\n",
         "    \"\"\"Trains a linear regression model.\n",
@@ -235,33 +276,43 @@
         "    # Return the next batch of data.\n",
         "    features, labels = ds.make_one_shot_iterator().get_next()\n",
         "    return features, labels"
-      ]
-    },
-    {
+      ],
       "cell_type": "code",
       "execution_count": 0,
+      "outputs": []
+    },
+    {
       "metadata": {
-        "colab": {},
+        "id": "bLzK72jkNJPf",
         "colab_type": "code",
-        "id": "bLzK72jkNJPf"
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
       },
-      "outputs": [],
       "source": [
         "def get_quantile_based_buckets(feature_values, num_buckets):\n",
         "  quantiles = feature_values.quantile(\n",
         "    [(i+1.)/(num_buckets + 1.) for i in range(num_buckets)])\n",
         "  return [quantiles[q] for q in quantiles.keys()]"
-      ]
-    },
-    {
+      ],
       "cell_type": "code",
       "execution_count": 0,
+      "outputs": []
+    },
+    {
       "metadata": {
-        "colab": {},
+        "id": "al2YQpKyIjnd",
         "colab_type": "code",
-        "id": "al2YQpKyIjnd"
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
       },
-      "outputs": [],
       "source": [
         "def construct_feature_columns():\n",
         "  \"\"\"Construct the TensorFlow Feature Columns.\n",
@@ -316,29 +367,34 @@
         "    bucketized_rooms_per_person])\n",
         "  \n",
         "  return feature_columns"
-      ]
+      ],
+      "cell_type": "code",
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "hSBwMrsrE21n"
+        "id": "hSBwMrsrE21n",
+        "colab_type": "text"
       },
       "source": [
         "## Calculate the Model Size\n",
         "\n",
         "To calculate the model size, we simply count the number of parameters that are non-zero. We provide a helper function below to do that. The function uses intimate knowledge of the Estimators API - don't worry about understanding how it works."
-      ]
+      ],
+      "cell_type": "markdown"
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
+        "id": "e6GfTI0CFhB8",
         "colab_type": "code",
-        "id": "e6GfTI0CFhB8"
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
       },
-      "outputs": [],
       "source": [
         "def model_size(estimator):\n",
         "  variables = estimator.get_variable_names()\n",
@@ -352,13 +408,15 @@
         "              ):\n",
         "      size += np.count_nonzero(estimator.get_variable_value(variable))\n",
         "  return size"
-      ]
+      ],
+      "cell_type": "code",
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "XabdAaj67GfF"
+        "id": "XabdAaj67GfF",
+        "colab_type": "text"
       },
       "source": [
         "## Reduce the Model Size\n",
@@ -368,13 +426,13 @@
         "Since the SmartRing is small, the engineering team has determined that it can only handle a model that has **no more than 600 parameters**. On the other hand, the product management team has determined that the model is not launchable unless the **LogLoss is less than 0.35** on the holdout test set.\n",
         "\n",
         "Can you use your secret weapon—L1 regularization—to tune the model to satisfy both the size and accuracy constraints?"
-      ]
+      ],
+      "cell_type": "markdown"
     },
     {
-      "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "G79hGRe7qqej"
+        "id": "G79hGRe7qqej",
+        "colab_type": "text"
       },
       "source": [
         "### Task 1: Find a good regularization coefficient.\n",
@@ -384,17 +442,20 @@
         "The following code will help you get started. There are many ways to apply regularization to your model. Here, we chose to do it using `FtrlOptimizer`, which is designed to give better results with L1 regularization than standard gradient descent.\n",
         "\n",
         "Again, the model will train on the entire data set, so expect it to run slower than normal."
-      ]
+      ],
+      "cell_type": "markdown"
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
+        "id": "1Fcdm0hpIjnl",
         "colab_type": "code",
-        "id": "1Fcdm0hpIjnl"
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
       },
-      "outputs": [],
       "source": [
         "def train_linear_classifier_model(\n",
         "    learning_rate,\n",
@@ -494,17 +555,22 @@
         "  plt.legend()\n",
         "\n",
         "  return linear_classifier"
-      ]
-    },
-    {
+      ],
       "cell_type": "code",
       "execution_count": 0,
+      "outputs": []
+    },
+    {
       "metadata": {
-        "colab": {},
+        "id": "9H1CKHSzIjno",
         "colab_type": "code",
-        "id": "9H1CKHSzIjno"
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
       },
-      "outputs": [],
       "source": [
         "linear_classifier = train_linear_classifier_model(\n",
         "    learning_rate=0.1,\n",
@@ -518,39 +584,44 @@
         "    validation_examples=validation_examples,\n",
         "    validation_targets=validation_targets)\n",
         "print(\"Model size:\", model_size(linear_classifier))"
-      ]
+      ],
+      "cell_type": "code",
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "yjUCX5LAkxAX"
+        "id": "yjUCX5LAkxAX",
+        "colab_type": "text"
       },
       "source": [
         "### Solution\n",
         "\n",
         "Click below to see a possible solution."
-      ]
+      ],
+      "cell_type": "markdown"
     },
     {
-      "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "hgGhy-okmkWL"
+        "id": "hgGhy-okmkWL",
+        "colab_type": "text"
       },
       "source": [
         "Because you're reducing model size while training on a toy dataset, you're forced to raise regularization strength to `0.8`, which is anomalously high. When training on real-world datasets, regularization strength is much smaller than `0.8`. Note that you're trading off model size versus loss. As you decrease model size by increasing regularization, your loss can increase."
-      ]
+      ],
+      "cell_type": "markdown"
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
+        "id": "_rV8YQWZIjns",
         "colab_type": "code",
-        "id": "_rV8YQWZIjns"
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
       },
-      "outputs": [],
       "source": [
         "linear_classifier = train_linear_classifier_model(\n",
         "    learning_rate=0.1,\n",
@@ -563,23 +634,10 @@
         "    validation_examples=validation_examples,\n",
         "    validation_targets=validation_targets)\n",
         "print(\"Model size:\", model_size(linear_classifier))"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "collapsed_sections": [
-        "JndnmDMp66FL"
       ],
-      "name": "sparsity_and_l1_regularization.ipynb",
-      "provenance": [],
-      "version": "0.3.2"
-    },
-    "kernelspec": {
-      "display_name": "Python 2",
-      "name": "python2"
+      "cell_type": "code",
+      "execution_count": 0,
+      "outputs": []
     }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  ]
 }


### PR DESCRIPTION
The exercise asks you to increase regularization such that the model size reduces below 600 parameters. The solution sets regularization to 0.1. However, setting regularization_strength=0.1 resulted in a model size of 753. Setting regularization_strength=0.7 resulted in a model size of 596. Hence, this change.

The other option is to change the exercise's goal to ~753. However, without regularization, model size is 791. So 753 isn't much of a difference. Hence, I chose to keep the goal and change the regularization.