### PR TITLE
Update image classification examples to Python3.

### DIFF
--- a/ml/pc/exercises/image_classification_part1.ipynb
+++ b/ml/pc/exercises/image_classification_part1.ipynb
@@ -200,11 +200,11 @@
       "outputs": [],
       "source": [
         "train_cat_fnames = os.listdir(train_cats_dir)\n",
-        "print train_cat_fnames[:10]\n",
+        "print(train_cat_fnames[:10])\n",
         "\n",
         "train_dog_fnames = os.listdir(train_dogs_dir)\n",
         "train_dog_fnames.sort()\n",
-        "print train_dog_fnames[:10]"
+        "print(train_dog_fnames[:10])"
       ]
     },
     {
@@ -232,10 +232,10 @@
       },
       "outputs": [],
       "source": [
-        "print 'total training cat images:', len(os.listdir(train_cats_dir))\n",
-        "print 'total training dog images:', len(os.listdir(train_dogs_dir))\n",
-        "print 'total validation cat images:', len(os.listdir(validation_cats_dir))\n",
-        "print 'total validation dog images:', len(os.listdir(validation_dogs_dir))"
+        "print('total training cat images:', len(os.listdir(train_cats_dir)))\n",
+        "print('total training dog images:', len(os.listdir(train_dogs_dir)))\n",
+        "print('total validation cat images:', len(os.listdir(validation_cats_dir)))\n",
+        "print('total validation dog images:', len(os.listdir(validation_dogs_dir)))"
       ]
     },
     {

--- a/ml/pc/exercises/image_classification_part3.ipynb
+++ b/ml/pc/exercises/image_classification_part3.ipynb
@@ -211,7 +211,7 @@
       "outputs": [],
       "source": [
         "last_layer = pre_trained_model.get_layer('mixed7')\n",
-        "print 'last layer output shape:', last_layer.output_shape\n",
+        "print('last layer output shape:', last_layer.output_shape)\n",
         "last_output = last_layer.output"
       ]
     },


### PR DESCRIPTION
The print statements lacked parentheses, which Python3 requires.