### PR TITLE
Fix model creation to consider batch_size

### DIFF
--- a/ml/cc/exercises/linear_regression_with_synthetic_data.ipynb
+++ b/ml/cc/exercises/linear_regression_with_synthetic_data.ipynb
@@ -247,7 +247,7 @@
         "  # relate to the label values. \n",
         "  history = model.fit(x=feature,\n",
         "                      y=label,\n",
-        "                      batch_size=None,\n",
+        "                      batch_size=batch_size,\n",
         "                      epochs=epochs)\n",
         "\n",
         "  # Gather the trained model's weight and bias.\n",


### PR DESCRIPTION
The input variable batch size cannot be ignored by the function that creates that model.
Hard-coding the value to None breaks the last Task of this Notebook.