### PR TITLE
Fix index offset in predict_house_values

### DIFF
--- a/ml/cc/exercises/linear_regression_with_a_real_dataset.ipynb
+++ b/ml/cc/exercises/linear_regression_with_a_real_dataset.ipynb
@@ -531,8 +531,8 @@
         "  print(\"          in thousand$   in thousand$\")\n",
         "  print(\"--------------------------------------\")\n",
         "  for i in range(n):\n",
-        "    print (\"%5.0f %6.0f %15.0f\" % (training_df[feature][i],\n",
-        "                                   training_df[label][i],\n",
+        "    print (\"%5.0f %6.0f %15.0f\" % (training_df[feature][10000 + i],\n",
+        "                                   training_df[label][10000 + i],\n",
         "                                   predicted_values[i][0] ))"
       ],
       "execution_count": 0,


### PR DESCRIPTION
Printed rows should match rows used for prediction.