### PR TITLE
Fairness Indicators: Update example util import for 0.25

### DIFF
--- a/ml/pc/exercises/fairness_text_toxicity_part1.ipynb
+++ b/ml/pc/exercises/fairness_text_toxicity_part1.ipynb
@@ -133,7 +133,7 @@
         "import tensorflow_data_validation as tfdv\n",
         "from tensorflow_model_analysis.addons.fairness.post_export_metrics import fairness_indicators\n",
         "from tensorflow_model_analysis.addons.fairness.view import widget_view\n",
-        "from fairness_indicators.examples import util\n",
+        "from fairness_indicators.documentation.examples import util\n",
         "\n",
         "from witwidget.notebook.visualization import WitConfigBuilder\n",
         "from witwidget.notebook.visualization import WitWidget"


### PR DESCRIPTION
hello!  👋 

This notebook is linked to in [ML Practicum: Fairness in Perspective API](https://developers.google.com/machine-learning/practica/fairness-indicators/exercise-1), but the notebook code has an error:

<img width="1040" alt="Screen Shot 2020-12-08 at 3 09 07 PM" src="https://user-images.githubusercontent.com/1056957/101535963-5d05ad80-3967-11eb-86d6-e5d0266701d2.png">

It looks like this comes from an upstream change in the module organization in Fairness Indicators (https://github.com/tensorflow/fairness-indicators/pull/125), and this patch does the trick.  Thanks! 👍 

