### PR TITLE
incorrect test_csv in web version

### DIFF
--- a/ml/cc/exercises/intro_to_ml_fairness.ipynb
+++ b/ml/cc/exercises/intro_to_ml_fairness.ipynb
@@ -248,7 +248,7 @@
         "\n",
         "train_csv = tf.keras.utils.get_file('adult.data', \n",
         "  'https://download.mlcc.google.com/mledu-datasets/adult_census_train.csv')\n",
-        "test_csv = tf.keras.utils.get_file('adult.test', \n",
+        "test_csv = tf.keras.utils.get_file('adult.test' , \n",
         "  'https://download.mlcc.google.com/mledu-datasets/adult_census_test.csv')\n",
         "\n",
         "train_df = pd.read_csv(train_csv, names=COLUMNS, sep=r'\\s*,\\s*', \n",

--- a/ml/cc/exercises/linear_regression_with_synthetic_data.ipynb
+++ b/ml/cc/exercises/linear_regression_with_synthetic_data.ipynb
@@ -667,7 +667,7 @@
         "\n",
         " * Training loss should steadily decrease, steeply at first, and then more slowly until the slope of the curve reaches or approaches zero. \n",
         " * If the training loss does not converge, train for more epochs.\n",
-        " * If the training loss decreases too slowly, increase the learning rate. Note that setting the training loss too high may also prevent training loss from converging.\n",
+        " * If the training loss decreases too slowly, increase the learning rate. Note that setting the learning rate too high may also prevent training loss from converging.\n",
         " * If the training loss varies wildly (that is, the training loss jumps around), decrease the learning rate.\n",
         " * Lowering the learning rate while increasing the number of epochs or the batch size is often a good combination.\n",
         " * Setting the batch size to a *very* small batch number can also cause instability. First, try large batch size values. Then, decrease the batch size until you see degradation.\n",


### PR DESCRIPTION
The code here in github is correct, but the code published in the web is not
https://colab.research.google.com/github/google/eng-edu/blob/master/ml/cc/exercises/intro_to_ml_fairness.ipynb#scrollTo=-xgIRapb5LaQ
test_csv = .... adult.data
should be adult.test
![image](https://user-images.githubusercontent.com/130455/102726595-e9539100-42d4-11eb-8667-93c64405ab35.png)
