### PR TITLE
fix typo in plot_frequency_distribution_of_ngrams

### DIFF
--- a/ml/guides/text_classification/explore_data.py
+++ b/ml/guides/text_classification/explore_data.py
@@ -72,7 +72,7 @@ def plot_frequency_distribution_of_ngrams(sample_texts,
     """
     # Create args required for vectorizing.
     kwargs = {
-            'ngram_range': (1, 1),
+            'ngram_range': ngram_range,
             'dtype': 'int32',
             'strip_accents': 'unicode',
             'decode_error': 'replace',


### PR DESCRIPTION
I believe there is a typo in the `plot_frequency_distribution_of_ngrams` function, in `explore_data.py` (under text classification guides).

`ngram_range` is a parameter that currently never gets used.