### PR TITLE
Typo: suffle -> shuffle

### DIFF
--- a/ml/cc/exercises/representation_with_a_feature_cross.ipynb
+++ b/ml/cc/exercises/representation_with_a_feature_cross.ipynb
@@ -161,7 +161,7 @@
         "* `train_df`, which contains the training set\n",
         "* `test_df`, which contains the test set\n",
         "\n",
-        "The code cell then scales the `median_house_value` to a more human-friendly range and then suffles the examples."
+        "The code cell then scales the `median_house_value` to a more human-friendly range and then shuffles the examples."
       ]
     },
     {


### PR DESCRIPTION
Just a typo.