### PR TITLE
Update print for python3 and remove unnecessary code for type conversion

### DIFF
--- a/ml/clustering/clustering-manual-similarity.ipynb
+++ b/ml/clustering/clustering-manual-similarity.ipynb
@@ -4,19 +4,24 @@
   "metadata": {
     "colab": {
       "name": "Colab - Manual Similarity with Chocolates",
-      "version": "0.3.2",
       "provenance": [],
       "collapsed_sections": [
         "9EjQt_o9Xf_L",
         "tj67XUzmjuNK"
       ]
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
     }
   },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "9EjQt_o9Xf_L"
       },
       "source": [
@@ -27,9 +32,7 @@
       "cell_type": "code",
       "metadata": {
         "cellView": "both",
-        "colab_type": "code",
-        "id": "oXzTW-CnXf_Q",
-        "colab": {}
+        "id": "oXzTW-CnXf_Q"
       },
       "source": [
         "#@title\n",
@@ -45,13 +48,12 @@
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "9NkysjxvKAli"
       },
       "source": [
@@ -74,7 +76,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "2X92CHu-KDOi"
       },
       "source": [
@@ -89,9 +90,7 @@
       "cell_type": "code",
       "metadata": {
         "cellView": "form",
-        "colab_type": "code",
-        "id": "Sq-yxIzRO4R2",
-        "colab": {}
+        "id": "Sq-yxIzRO4R2"
       },
       "source": [
         "#@title Run cell to load and clean the dataset\n",
@@ -191,13 +190,12 @@
         "\n",
         "choc_data.head()"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "aIOACI88KI1k"
       },
       "source": [
@@ -207,7 +205,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "V9aJj0d2LdDG"
       },
       "source": [
@@ -226,20 +223,17 @@
       "cell_type": "code",
       "metadata": {
         "cellView": "both",
-        "colab_type": "code",
-        "id": "bJ-3B0OaKRyT",
-        "colab": {}
+        "id": "bJ-3B0OaKRyT"
       },
       "source": [
         "sns.distplot(choc_data['review_date'])"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "AYk5VR93feJm"
       },
       "source": [
@@ -250,21 +244,18 @@
       "cell_type": "code",
       "metadata": {
         "cellView": "both",
-        "colab_type": "code",
-        "id": "8XQ5CZ0uFIlh",
-        "colab": {}
+        "id": "8XQ5CZ0uFIlh"
       },
       "source": [
         "# check the distribution\n",
         "sns.distplot(choc_data['rating'])"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "01RF1MRDAPjC"
       },
       "source": [
@@ -275,22 +266,19 @@
       "cell_type": "code",
       "metadata": {
         "cellView": "both",
-        "colab_type": "code",
-        "id": "fl9HsbYIoJkl",
-        "colab": {}
+        "id": "fl9HsbYIoJkl"
       },
       "source": [
         "# its a Gaussian! So, use z-score to normalize the data\n",
         "choc_data['rating_norm'] = (choc_data['rating'] - choc_data['rating'].mean()\n",
         "                           ) / choc_data['rating'].std()"
       ],
-      "execution_count": 0,
+      "execution_count": 4,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "3fDeI_0cftzz"
       },
       "source": [
@@ -301,20 +289,17 @@
       "cell_type": "code",
       "metadata": {
         "cellView": "both",
-        "colab_type": "code",
-        "id": "nIQSWYYLGQeK",
-        "colab": {}
+        "id": "nIQSWYYLGQeK"
       },
       "source": [
         "sns.distplot(choc_data['cocoa_percent'])"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "zpJgcmP9Aedg"
       },
       "source": [
@@ -325,22 +310,19 @@
       "cell_type": "code",
       "metadata": {
         "cellView": "both",
-        "colab_type": "code",
-        "id": "1YSde7nloLt5",
-        "colab": {}
+        "id": "1YSde7nloLt5"
       },
       "source": [
         "choc_data['cocoa_percent_norm'] = (\n",
         "    choc_data['cocoa_percent'] -\n",
         "    choc_data['cocoa_percent'].mean()) / choc_data['cocoa_percent'].std()"
       ],
-      "execution_count": 0,
+      "execution_count": 6,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "qcGL7gHygH06"
       },
       "source": [
@@ -350,20 +332,17 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab_type": "code",
-        "id": "_-TKLnZQgIhR",
-        "colab": {}
+        "id": "_-TKLnZQgIhR"
       },
       "source": [
         "choc_data.head()"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "zNn0n3Kqf5Ta"
       },
       "source": [
@@ -381,9 +360,7 @@
       "cell_type": "code",
       "metadata": {
         "cellView": "form",
-        "colab_type": "code",
-        "id": "AdJyelmJJ-9h",
-        "colab": {}
+        "id": "AdJyelmJJ-9h"
       },
       "source": [
         "#@title Run code to add latitude and longitude data\n",
@@ -416,13 +393,12 @@
         "\n",
         "choc_data.head()"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "NBoiApVwgRb5"
       },
       "source": [
@@ -433,20 +409,17 @@
       "cell_type": "code",
       "metadata": {
         "cellView": "both",
-        "colab_type": "code",
-        "id": "6yImioS8Lqwd",
-        "colab": {}
+        "id": "6yImioS8Lqwd"
       },
       "source": [
         "sns.distplot(choc_data['maker_lat'])"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Cg1t5qmngcCZ"
       },
       "source": [
@@ -458,9 +431,7 @@
       "cell_type": "code",
       "metadata": {
         "cellView": "both",
-        "colab_type": "code",
-        "id": "2RsiAsB3HRqu",
-        "colab": {}
+        "id": "2RsiAsB3HRqu"
       },
       "source": [
         "numQuantiles = 20\n",
@@ -475,13 +446,12 @@
         "  \n",
         "choc_data.tail()"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "fpT98u1JWfoE"
       },
       "source": [
@@ -491,9 +461,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab_type": "code",
-        "id": "ypMg6cVxW0Uq",
-        "colab": {}
+        "id": "ypMg6cVxW0Uq"
       },
       "source": [
         "def minMaxScaler(numArr):\n",
@@ -506,13 +474,12 @@
         "for string in colsQuantiles:\n",
         "  choc_data[string] = minMaxScaler(choc_data[string])"
       ],
-      "execution_count": 0,
+      "execution_count": 11,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "m23IAig1WonY"
       },
       "source": [
@@ -524,9 +491,7 @@
       "cell_type": "code",
       "metadata": {
         "cellView": "both",
-        "colab_type": "code",
-        "id": "pZ29GSFWSTJA",
-        "colab": {}
+        "id": "pZ29GSFWSTJA"
       },
       "source": [
         "# duplicate the \"maker\" feature since it's removed by one-hot encoding function\n",
@@ -536,13 +501,12 @@
         "choc_data['bean_type2'] = choc_data['bean_type']\n",
         "choc_data = pd.get_dummies(choc_data, columns=['bean_type2'], prefix=['bean'])"
       ],
-      "execution_count": 0,
+      "execution_count": 12,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "k3pEOmohW9q5"
       },
       "source": [
@@ -555,9 +519,7 @@
       "cell_type": "code",
       "metadata": {
         "cellView": "both",
-        "colab_type": "code",
-        "id": "3pJutwixXpfy",
-        "colab": {}
+        "id": "3pJutwixXpfy"
       },
       "source": [
         "# Split dataframe into two frames: Original data and data for clustering\n",
@@ -569,13 +531,12 @@
         "# Note: In the latest version of \"get_dummies\", you can set \"dtype\" to float\n",
         "choc_data = choc_data / 1.0"
       ],
-      "execution_count": 0,
+      "execution_count": 13,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "TU1UQNP2pIcT"
       },
       "source": [
@@ -587,20 +548,17 @@
       "cell_type": "code",
       "metadata": {
         "cellView": "both",
-        "colab_type": "code",
-        "id": "nwWcnf4IpF7V",
-        "colab": {}
+        "id": "nwWcnf4IpF7V"
       },
       "source": [
         "choc_data.tail()"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "E2HuxR-UcDOw"
       },
       "source": [
@@ -610,7 +568,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "G7Fi6dMBTL1g"
       },
       "source": [
@@ -626,16 +583,14 @@
       "cell_type": "code",
       "metadata": {
         "cellView": "both",
-        "colab_type": "code",
-        "id": "zBGUouTEcAz3",
-        "colab": {}
+        "id": "zBGUouTEcAz3"
       },
       "source": [
         "def getSimilarity(obj1, obj2):\n",
         "  len1 = len(obj1.index)\n",
         "  len2 = len(obj2.index)\n",
         "  if not (len1 == len2):\n",
-        "    print \"Error: Compared objects must have same number of features.\"\n",
+        "    print (\"Error: Compared objects must have same number of features.\")\n",
         "    sys.exit()\n",
         "    return 0\n",
         "  else:\n",
@@ -644,13 +599,12 @@
         "    similarity = 1 - math.sqrt(similarity)\n",
         "    return similarity"
       ],
-      "execution_count": 0,
+      "execution_count": 16,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Ybig-jrATerQ"
       },
       "source": [
@@ -666,33 +620,29 @@
     {
       "cell_type": "code",
       "metadata": {
-        "cellView": "form",
-        "colab_type": "code",
-        "id": "Tylgxe-FM6NP",
-        "colab": {}
+        "id": "Tylgxe-FM6NP"
       },
       "source": [
         "choc1 = 0  #@param\n",
         "chocsToCompare = [1, 4]  #@param\n",
         "\n",
-        "print \"Similarity between chocolates \" + str(choc1) + \" and ...\"\n",
+        "print (\"Similarity between chocolates \" + str(choc1) + \" and ...\")\n",
         "\n",
         "for ii in range(chocsToCompare[0], chocsToCompare[1] + 1):\n",
-        "  print str(ii) + \": \" + str(\n",
-        "      getSimilarity(choc_data.loc[choc1], choc_data.loc[ii]))\n",
+        "  print (str(ii) + \": \" + str(\n",
+        "      getSimilarity(choc_data.loc[choc1], choc_data.loc[ii])))\n",
         "\n",
-        "print \"\\n\\nFeature data for chocolate \" + str(choc1)\n",
-        "print choc_data_backup.loc[choc1:choc1, :]\n",
-        "print \"\\n\\nFeature data for compared chocolates \" + str(chocsToCompare)\n",
-        "print choc_data_backup.loc[chocsToCompare[0]:chocsToCompare[1], :]"
+        "print (\"\\n\\nFeature data for chocolate \" + str(choc1))\n",
+        "print (choc_data_backup.loc[choc1:choc1, :])\n",
+        "print (\"\\n\\nFeature data for compared chocolates \" + str(chocsToCompare))\n",
+        "print (choc_data_backup.loc[chocsToCompare[0]:chocsToCompare[1], :])"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "ImOGD5GJ8Ia7"
       },
       "source": [
@@ -711,10 +661,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "cellView": "form",
-        "colab_type": "code",
-        "id": "eExms-TP8Hn6",
-        "colab": {}
+        "id": "eExms-TP8Hn6"
       },
       "source": [
         "#@title Run cell to setup functions\n",
@@ -799,23 +746,22 @@
         "    newMapping = df['centroid']\n",
         "    flagConvergence = all(oldMapping == newMapping)\n",
         "    if verbose == 1:\n",
-        "      print 'Total distance:' + str(np.sum(df['pt2centroid']))\n",
+        "      print ('Total distance:' + str(np.sum(df['pt2centroid'])))\n",
         "    if (iter > maxIter):\n",
-        "      print 'k-means did not converge! Reached maximum iteration limit of ' \\\n",
-        "            + str(maxIter) + '.'\n",
+        "      print ('k-means did not converge! Reached maximum iteration limit of ' \\\n",
+        "            + str(maxIter) + '.')\n",
         "      sys.exit()\n",
         "      return\n",
-        "  print 'k-means converged for ' + str(k) + ' clusters' + \\\n",
-        "        ' after ' + str(iter) + ' iterations!'\n",
+        "  print ('k-means converged for ' + str(k) + ' clusters' + \\\n",
+        "        ' after ' + str(iter) + ' iterations!')\n",
         "  return [df, centroids]"
       ],
-      "execution_count": 0,
+      "execution_count": 21,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "-KnRLWvw1rJ9"
       },
       "source": [
@@ -828,10 +774,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "cellView": "form",
-        "colab_type": "code",
-        "id": "AKDwhN9J1PhU",
-        "colab": {}
+        "id": "AKDwhN9J1PhU"
       },
       "source": [
         "k = 30  #@param\n",
@@ -846,13 +789,12 @@
         "      ' the extreme right:')\n",
         "choc_data.head()"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "bfFShL6wqa-9"
       },
       "source": [
@@ -862,7 +804,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "13TnsPz23xOU"
       },
       "source": [
@@ -880,22 +821,18 @@
     {
       "cell_type": "code",
       "metadata": {
-        "cellView": "form",
-        "colab_type": "code",
-        "id": "NHWgGmpyux39",
-        "colab": {}
+        "id": "NHWgGmpyux39"
       },
       "source": [
         "clusterNumber = 7  #@param\n",
         "choc_data_backup.loc[choc_data['centroid'] == clusterNumber, :]"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "MJtuP9w5jJHq"
       },
       "source": [
@@ -907,7 +844,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "gxiPD8g_jShi"
       },
       "source": [
@@ -935,7 +871,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Z1eW0PlG57Zs"
       },
       "source": [
@@ -951,16 +886,13 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab_type": "code",
-        "id": "i9Y2H-nR56C3",
-        "colab": {}
+        "id": "i9Y2H-nR56C3"
       },
       "source": [
         "#@title Run cell to set up functions { display-mode: \"form\" }\n",
         "def clusterCardinality(df):\n",
         "  k = np.max(df['centroid']) + 1\n",
-        "  k = k.astype(int)\n",
-        "  print 'Number of clusters:' + str(k)\n",
+        "  print ('Number of clusters:' + str(k))\n",
         "  clCard = np.zeros(k)\n",
         "  for kk in range(k):\n",
         "    clCard[kk] = np.sum(df['centroid'] == kk)\n",
@@ -976,7 +908,6 @@
         "\n",
         "def clusterMagnitude(df):\n",
         "  k = np.max(df['centroid']) + 1\n",
-        "  k = k.astype(int)\n",
         "  cl = np.zeros(k)\n",
         "  clMag = np.zeros(k)\n",
         "  for kk in range(k):\n",
@@ -1007,13 +938,12 @@
         "  clMag = clusterMagnitude(df)\n",
         "  plotCardVsMag(clCard, clMag)"
       ],
-      "execution_count": 0,
+      "execution_count": 27,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "1nLYPlv4ejwD"
       },
       "source": [
@@ -1032,20 +962,17 @@
       "cell_type": "code",
       "metadata": {
         "cellView": "both",
-        "colab_type": "code",
-        "id": "3llKFtEpeiZ_",
-        "colab": {}
+        "id": "3llKFtEpeiZ_"
       },
       "source": [
         "clusterQualityMetrics(choc_data)"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "SBa0k9KK2PAt"
       },
       "source": [
@@ -1063,7 +990,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "LD9RQUIWjfwS"
       },
       "source": [
@@ -1075,10 +1001,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "cellView": "form",
-        "colab_type": "code",
-        "id": "-df7QnPlhuIN",
-        "colab": {}
+        "id": "-df7QnPlhuIN"
       },
       "source": [
         "# Plot loss vs number of clusters\n",
@@ -1102,13 +1025,12 @@
         "kstep = 2  # @param\n",
         "lossVsClusters(kmin, kmax, kstep, choc_data)"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "0wYfwKGcVT-R"
       },
       "source": [
@@ -1124,7 +1046,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "tj67XUzmjuNK"
       },
       "source": [
@@ -1138,7 +1059,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "pVEAjXut0uw7"
       },
       "source": [
@@ -1163,7 +1083,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "aZ12kbwD4Qtu"
       },
       "source": [
@@ -1186,10 +1105,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "cellView": "both",
-        "colab_type": "code",
-        "id": "T6hHN2bCKi7k",
-        "colab": {}
+        "id": "T6hHN2bCKi7k"
       },
       "source": [
         "#@title\n",
@@ -1206,11 +1122,11 @@
         "numCentroids = B.shape[0]\n",
         "pointNorms = np.reshape(nla.norm(A, axis=1)**2.0, [numPoints, 1])\n",
         "centroidNorms = np.reshape(nla.norm(B, axis=1)**2.0, (1, numCentroids))\n",
-        "print \"\"\"Distance matrix of size 'p' by 'c' where Distance between \n",
-        "point 'p' and centroid 'c' is at (p,c).\"\"\"\n",
-        "print pointNorms + centroidNorms - 2.0 * np.dot(A, np.transpose(B))"
+        "print (\"\"\"Distance matrix of size 'p' by 'c' where Distance between \n",
+        "point 'p' and centroid 'c' is at (p,c).\"\"\")\n",
+        "print (pointNorms + centroidNorms - 2.0 * np.dot(A, np.transpose(B)))"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     }
   ]


### PR DESCRIPTION
- **print** without parentheses not working with python3 so I added the parentheses 
- There were some type conversion on the k variable which is already of type int into int using the pandas' **astype** method and it was generating an error some I remove them too