### PR TITLE
Fix typo

### DIFF
--- a/ml/cc/exercises/intro_to_neural_nets.ipynb
+++ b/ml/cc/exercises/intro_to_neural_nets.ipynb
@@ -691,7 +691,7 @@
         "* `tf.keras.regularizers.l1` for L1 regularization\n",
         "* `tf.keras.regularizers.l2` for L2 regularization\n",
         "\n",
-        "Each of the preceding methods takes an `l` parameter, which adjusts the [regularization rate](https://developers.google.com/machine-learning/glossary/#regularization_rate). Assign a decimal value between 0 and 1.0 to `l`; the higher the decimal, the greater the regularization. For example, the following applies L2 regularization at a strength of 0.05. \n",
+        "Each of the preceding methods takes an `l` parameter, which adjusts the [regularization rate](https://developers.google.com/machine-learning/glossary/#regularization_rate). Assign a decimal value between 0 and 1.0 to `l`; the higher the decimal, the greater the regularization. For example, the following applies L2 regularization at a strength of 0.01. \n",
         "\n",
         "```\n",
         "model.add(tf.keras.layers.Dense(units=20, \n",


### PR DESCRIPTION
Currently code says `l=0.01`, but description says `0.05`.
