### PR TITLE
Remove quote to fix grammar of "two columns"

### DIFF
--- a/ml/cc/exercises/linear_regression_with_a_real_dataset.ipynb
+++ b/ml/cc/exercises/linear_regression_with_a_real_dataset.ipynb
@@ -806,7 +806,7 @@
         "\n",
         "  * `1.0`: perfect positive correlation; that is, when one attribute rises, the other attribute rises.\n",
         "  * `-1.0`: perfect negative correlation; that is, when one attribute rises, the other attribute falls. \n",
-        "  * `0.0`: no correlation; the two column's [are not linearly related](https://en.wikipedia.org/wiki/Correlation_and_dependence#/media/File:Correlation_examples2.svg).\n",
+        "  * `0.0`: no correlation; the two columns [are not linearly related](https://en.wikipedia.org/wiki/Correlation_and_dependence#/media/File:Correlation_examples2.svg).\n",
         "\n",
         "In general, the higher the absolute value of a correlation value, the greater its predictive power. For example, a correlation value of -0.8 implies far more predictive power than a correlation of -0.2.\n",
         "\n",


### PR DESCRIPTION
In this case, we are using the phrase "two columns" as the plural subject; it's
not used in a possessive case.