### PR TITLE
Fix optimizer call from tf.train to tf.keras

### DIFF
--- a/ml/testing-debugging/testing-debugging-ml-debugging.ipynb
+++ b/ml/testing-debugging/testing-debugging-ml-debugging.ipynb
@@ -235,7 +235,7 @@
         "\n",
         "# Model calculates loss using mean-square error (MSE)\n",
         "# Model trains using Adam optimizer with learning rate = 0.001\n",
-        "model.compile(optimizer=tf.train.AdamOptimizer(0.001),\n",
+        "model.compile(optimizer=tf.keras.optimizers.Adam(0.001),\n",
         "              loss='mse',\n",
         "             )\n",
         "\n",


### PR DESCRIPTION
The original call to optimizer tf.train.AdamOptimizer(0.001) is throwing an error.
Fixed it by using keras with tf.keras.optimizers.Adam(0.001)