### PR TITLE
Update to the latest version of contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,28 @@
-Want to contribute? Great! First, read this page (including the small print at the end).
+# How to Contribute
 
-### Before you contribute
-Before we can use your code, you must sign the
-[Google Individual Contributor License Agreement](https://developers.google.com/open-source/cla/individual?csw=1)
-(CLA), which you can do online. The CLA is necessary mainly because you own the copyright to your changes, even after your contribution becomes part of our codebase, so we need your permission to use and distribute your code. We also need to be sure of various other things. For instance that you'll tell us if you know that your code infringes on other people's patents. You don't have to sign the CLA until after you've submitted your code for review and a member has approved it, but you must do it before we can put your code into our codebase.
+We'd love to accept your patches and contributions to this project. There are
+just a few small guidelines you need to follow.
 
-Before you start working on a larger contribution, we recommend to get in touch with us first through the issue tracker with your idea so that we can help out and possibly guide you. Coordinating up front makes it much easier to avoid frustration later on.
+## Contributor License Agreement
 
-### Code reviews
-All submissions, including submissions by project members, require review. We use GitHub pull requests for this purpose.
+Contributions to this project must be accompanied by a Contributor License
+Agreement. You (or your employer) retain the copyright to your contribution;
+this simply gives us permission to use and redistribute your contributions as
+part of the project. Head over to <https://cla.developers.google.com/> to see
+your current agreements on file or to sign a new one.
 
-### Organization
-During our review and triage of incoming pull requests, we'll advise whether to include your contribution into the DataLab product, or maintain it as an installable, but separate component or library.
+You generally only need to submit a CLA once, so if you've already submitted one
+(even if it was for a different project), you probably don't need to do it
+again.
 
-### The small print
-Contributions made by corporations are covered by a different agreement than the one above, the Software Grant and Corporate Contributor License Agreement.
+## Code Reviews
 
+All submissions, including submissions by project members, require review. We
+use GitHub pull requests for this purpose. Consult
+[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
+information on using pull requests.
+
+## Community Guidelines
+
+This project follows [Google's Open Source Community
+Guidelines](https://opensource.google/conduct/).


### PR DESCRIPTION
This file is quite old and only mentioned individual CLA, not corporate CLA.

Replaced file contents with the latest version of
https://github.com/google/new-project/blob/master/docs/contributing.md