### PR TITLE
Update fairness_text_toxicity_part1.ipynb installs

### DIFF
--- a/ml/pc/exercises/fairness_text_toxicity_part1.ipynb
+++ b/ml/pc/exercises/fairness_text_toxicity_part1.ipynb
@@ -28,6 +28,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "colab_type": "text",
         "id": "HnU0fNSuG2aD"
       },
       "source": [
@@ -37,6 +38,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "colab_type": "text",
         "id": "iVkPBosnIFlu"
       },
       "source": [
@@ -67,6 +69,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "colab_type": "text",
         "id": "g0PSuIW-I8iP"
       },
       "source": [
@@ -82,18 +85,21 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "2z_xzJ40j9Q-"
+        "id": "2z_xzJ40j9Q-",
+        "colab_type": "code",
+        "colab": {}
       },
       "source": [
-        "!pip install fairness-indicators==0.38.0"
+         "!pip install fairness-indicators==0.38.0"
       ],
-      "execution_count": null,
+      "execution_count": 0,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "mdLlKWbIlxYH"
+        "id": "mdLlKWbIlxYH",
+        "colab_type": "text"
       },
       "source": [
         "Next, import all the dependencies we'll use in this exercise, which include Fairness Indicators, TensorFlow Model Analysis (tfma), TensorFlow Data Validation (tfdv), and the What-If tool (WIT):"
@@ -102,7 +108,9 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "6E__x2XkJDFW"
+        "colab_type": "code",
+        "id": "6E__x2XkJDFW",
+        "colab": {}
       },
       "source": [
         "%tensorflow_version 2.x\n",
@@ -124,12 +132,13 @@
         "from witwidget.notebook.visualization import WitConfigBuilder\n",
         "from witwidget.notebook.visualization import WitWidget"
       ],
-      "execution_count": null,
+      "execution_count": 0,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
+        "colab_type": "text",
         "id": "dNfRkjWWIKIs"
       },
       "source": [
@@ -140,7 +149,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "J3R2QWkru1WN"
+        "id": "J3R2QWkru1WN",
+        "colab_type": "text"
       },
       "source": [
         "### About the Civil Comments dataset\n",
@@ -151,7 +161,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "ZZswcJJMCDjU"
+        "id": "ZZswcJJMCDjU",
+        "colab_type": "text"
       },
       "source": [
         "The Civil Comments dataset comprises approximately 2 million public comments that were submitted to the [Civil Comments platform](https://medium.com/@aja_15265/saying-goodbye-to-civil-comments-41859d3a2b1d). [Jigsaw](https://jigsaw.google.com/) sponsored the effort to compile and annotate these comments for ongoing [research](https://arxiv.org/abs/1903.04561); they've also hosted competitions on [Kaggle](https://www.kaggle.com/c/jigsaw-unintended-bias-in-toxicity-classification) to help classify toxic comments as well as minimize unintended model bias. \n",
@@ -231,6 +242,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "colab_type": "text",
         "id": "0YNqAJW5JjZD"
       },
       "source": [
@@ -244,7 +256,9 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "duPWGTQAvYKK"
+        "id": "duPWGTQAvYKK",
+        "colab_type": "code",
+        "colab": {}
       },
       "source": [
         "download_original_data = False #@param {type:\"boolean\"}\n",
@@ -267,13 +281,14 @@
         "  validate_tf_file = tf.keras.utils.get_file('validate_tf_processed.tfrecord',\n",
         "                                             'https://storage.googleapis.com/civil_comments_dataset/validate_tf_processed.tfrecord')"
       ],
-      "execution_count": null,
+      "execution_count": 0,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "aLup7wY0_Q3K"
+        "id": "aLup7wY0_Q3K",
+        "colab_type": "text"
       },
       "source": [
         "### Explore the data distribution in TFDV\n",
@@ -286,19 +301,22 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "vkzcE_g8_m_h"
+        "id": "vkzcE_g8_m_h",
+        "colab_type": "code",
+        "colab": {}
       },
       "source": [
         "stats = tfdv.generate_statistics_from_tfrecord(data_location=train_tf_file)\n",
         "tfdv.visualize_statistics(stats)"
       ],
-      "execution_count": null,
+      "execution_count": 0,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "wZU1Djze6E-s"
+        "id": "wZU1Djze6E-s",
+        "colab_type": "text"
       },
       "source": [
         "### Exercise\n",
@@ -308,7 +326,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "ne2_vKAb-XGD"
+        "id": "ne2_vKAb-XGD",
+        "colab_type": "text"
       },
       "source": [
         "#### **1. How many total examples are in the training dataset?**"
@@ -317,7 +336,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "UFBqqnRD-Zkj"
+        "id": "UFBqqnRD-Zkj",
+        "colab_type": "text"
       },
       "source": [
         "#### Solution\n",
@@ -328,7 +348,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "XSkOfchI-arC"
+        "id": "XSkOfchI-arC",
+        "colab_type": "text"
       },
       "source": [
         "**There are 1.08 million total examples in the training dataset.**\n",
@@ -343,7 +364,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "_PgFNm6sAZB2"
+        "id": "_PgFNm6sAZB2",
+        "colab_type": "text"
       },
       "source": [
         "#### **2. How many unique values are there for the `gender` feature? What are they, and what are the frequencies of each of these values?**\n",
@@ -356,7 +378,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "6KmrCS-uAz0s"
+        "id": "6KmrCS-uAz0s",
+        "colab_type": "text"
       },
       "source": [
         "#### Solution\n",
@@ -367,7 +390,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "wkc7P1nvA4cw"
+        "id": "wkc7P1nvA4cw",
+        "colab_type": "text"
       },
       "source": [
         "The **unique** column of the **Categorical Features** table tells us that there are 4 unique values for the `gender` feature.\n",
@@ -385,7 +409,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "NDUO57bdNUQR"
+        "id": "NDUO57bdNUQR",
+        "colab_type": "text"
       },
       "source": [
         "**NOTE:** As described [earlier](#scrollTo=J3R2QWkru1WN), a `gender` feature can contain zero or more of these 4 values, depending on the content of the comment. For example, a comment containing the text \"I am a transgender man\" will have both `transgender` and `male` as `gender` values, whereas a comment that does not reference gender at all will have an empty/false `gender` value."
@@ -394,7 +419,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "wX62Ktwp-qoF"
+        "id": "wX62Ktwp-qoF",
+        "colab_type": "text"
       },
       "source": [
         "#### **3. What percentage of total examples are labeled toxic? Overall, is this a class-balanced dataset (relatively even split of examples between positive and negative classes) or a class-imbalanced dataset (majority of examples are in one class)?**\n",
@@ -405,7 +431,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "IvvxNMgM-6A2"
+        "id": "IvvxNMgM-6A2",
+        "colab_type": "text"
       },
       "source": [
         "#### Solution\n",
@@ -416,7 +443,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "QmCtkzZqOvC2"
+        "id": "QmCtkzZqOvC2",
+        "colab_type": "text"
       },
       "source": [
         "**7.98 percent of examples are toxic.**\n",
@@ -431,7 +459,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "9MGLCsVhGWz0"
+        "id": "9MGLCsVhGWz0",
+        "colab_type": "text"
       },
       "source": [
         "#### **4. Run the following code to analyze label distribution for the subset of examples that contain a `gender` value**"
@@ -440,7 +469,10 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "f5pEWIkgLTKz"
+        "id": "f5pEWIkgLTKz",
+        "colab_type": "code",
+        "cellView": "form",
+        "colab": {}
       },
       "source": [
         "#@title Calculate label distribution for gender-related examples\n",
@@ -461,13 +493,14 @@
         "print(\"Toxic Gender Examples: %s\" % toxic_gender_examples)\n",
         "print(\"Nontoxic Gender Examples: %s\" % nontoxic_gender_examples)"
       ],
-      "execution_count": null,
+      "execution_count": 0,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "WJag4cEKNINy"
+        "id": "WJag4cEKNINy",
+        "colab_type": "text"
       },
       "source": [
         "#### **What percentage of `gender` examples are labeled toxic? Compare this percentage to the percentage of total examples that are labeled toxic from #3 above. What, if any, fairness concerns can you identify based on this comparison?**"
@@ -476,7 +509,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "-J4hbOhgHZid"
+        "id": "-J4hbOhgHZid",
+        "colab_type": "text"
       },
       "source": [
         "#### Solution\n",
@@ -487,7 +521,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "2KK3VWzkHmJ7"
+        "id": "2KK3VWzkHmJ7",
+        "colab_type": "text"
       },
       "source": [
         "There are 7,189 gender-related examples that are labeled toxic, which represent 14.7% of all gender-related examples.\n",
@@ -500,7 +535,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "5WHVYnlGX7g8"
+        "id": "5WHVYnlGX7g8",
+        "colab_type": "text"
       },
       "source": [
         "## Part II: Train the model"
@@ -509,7 +545,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "Xi5nnJ3hX9OO"
+        "id": "Xi5nnJ3hX9OO",
+        "colab_type": "text"
       },
       "source": [
         "In this section, you'll train a classifier on the Civil Comments dataset to predict whether a given text comment is toxic or not."
@@ -518,7 +555,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "ZCYUx0uVAz7v"
+        "id": "ZCYUx0uVAz7v",
+        "colab_type": "text"
       },
       "source": [
         "### Configure model input\n",
@@ -531,7 +569,9 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "SXqU-HJlB0fG"
+        "id": "SXqU-HJlB0fG",
+        "colab_type": "code",
+        "colab": {}
       },
       "source": [
         "TEXT_FEATURE = 'comment_text'\n",
@@ -551,13 +591,14 @@
         "    'disability':tf.io.VarLenFeature(tf.string),\n",
         "}"
       ],
-      "execution_count": null,
+      "execution_count": 0,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "OlEoDYlvMABU"
+        "id": "OlEoDYlvMABU",
+        "colab_type": "text"
       },
       "source": [
         "The input function below specifies how to preprocess and batch the training data into the model. \n",
@@ -571,7 +612,9 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "ZaaKKjYwP6XY"
+        "id": "ZaaKKjYwP6XY",
+        "colab_type": "code",
+        "colab": {}
       },
       "source": [
         "def train_input_fn():\n",
@@ -586,12 +629,13 @@
         "      filenames=[train_tf_file]).map(parse_function).batch(512)\n",
         "  return train_dataset"
       ],
-      "execution_count": null,
+      "execution_count": 0,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
+        "colab_type": "text",
         "id": "EX92OLF2MKSu"
       },
       "source": [
@@ -605,7 +649,9 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "2qW8TlgVRzFc"
+        "colab_type": "code",
+        "id": "2qW8TlgVRzFc",
+        "colab": {}
       },
       "source": [
         "BASE_DIR = tempfile.gettempdir()\n",
@@ -628,13 +674,14 @@
         "\n",
         "classifier.train(input_fn=train_input_fn, steps=1000)"
       ],
-      "execution_count": null,
+      "execution_count": 0,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "EjNbZGqFYCUy"
+        "id": "EjNbZGqFYCUy",
+        "colab_type": "text"
       },
       "source": [
         "## Part III: Run Fairness Indicators\n",
@@ -645,7 +692,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "EXd2-UzFbAwE"
+        "id": "EXd2-UzFbAwE",
+        "colab_type": "text"
       },
       "source": [
         "### Export the model"
@@ -654,7 +702,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "jMYWdUaUbIb-"
+        "id": "jMYWdUaUbIb-",
+        "colab_type": "text"
       },
       "source": [
         "First, let's export the model we trained in the [previous section](#scrollTo=5WHVYnlGX7g8), so that we can analyze the results using [TensorFlow Model Analysis (TFMA)](https://www.tensorflow.org/tfx/model_analysis/get_started)."
@@ -663,7 +712,9 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "R-7dDws2bHxS"
+        "id": "R-7dDws2bHxS",
+        "colab_type": "code",
+        "colab": {}
       },
       "source": [
         "def eval_input_receiver_fn():\n",
@@ -687,13 +738,14 @@
         "  export_dir_base=os.path.join(BASE_DIR, 'tfma_eval_model'),\n",
         "  eval_input_receiver_fn=eval_input_receiver_fn)"
       ],
-      "execution_count": null,
+      "execution_count": 0,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "Xq8NWjzUcAhA"
+        "id": "Xq8NWjzUcAhA",
+        "colab_type": "text"
       },
       "source": [
         "### Compute fairness metrics\n",
@@ -707,7 +759,9 @@
       "cell_type": "code",
       "metadata": {
         "id": "Pkuti2_8cR2D",
-        "cellView": "both"
+        "colab_type": "code",
+        "cellView": "both",
+        "colab": {}
       },
       "source": [
         "tfma_eval_result_path = os.path.join(BASE_DIR, 'tfma_eval_result')\n",
@@ -757,12 +811,13 @@
         "\n",
         "eval_result = tfma.load_eval_result(output_path=tfma_eval_result_path)"
       ],
-      "execution_count": null,
+      "execution_count": 0,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
+        "colab_type": "text",
         "id": "BssBGpqmwBMd"
       },
       "source": [
@@ -772,18 +827,21 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "HFlK9U40dyDk"
+        "colab_type": "code",
+        "id": "HFlK9U40dyDk",
+        "colab": {}
       },
       "source": [
         "widget_view.render_fairness_indicator(eval_result=eval_result, slicing_column=slice_selection)"
       ],
-      "execution_count": null,
+      "execution_count": 0,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "wEMcXd8ZO_T4"
+        "id": "wEMcXd8ZO_T4",
+        "colab_type": "text"
       },
       "source": [
         "**NOTE:** The categories above are not mutually exclusive, as examples can be tagged with zero or more of these gender-identity terms. An example with gender values of both `transgender` and `female` will be represented in both the `gender:transgender` and `gender:female` slices."
@@ -792,6 +850,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "colab_type": "text",
         "id": "R-pA9MSPOl1_"
       },
       "source": [
@@ -809,7 +868,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "YPDRjcKZk3EL"
+        "id": "YPDRjcKZk3EL",
+        "colab_type": "text"
       },
       "source": [
         "#### **1. What are the overall false positive rate (FPR) and false negative rate (FNR) for the model at a classification threshold of 0.5?**"
@@ -818,7 +878,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "tGyACRd8oFwP"
+        "id": "tGyACRd8oFwP",
+        "colab_type": "text"
       },
       "source": [
         "#### Solution\n",
@@ -829,7 +890,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "QzmJGSTYsEYx"
+        "id": "QzmJGSTYsEYx",
+        "colab_type": "text"
       },
       "source": [
         "Select a threshold of 0.5 in the dropdown at the the top of the widget. To view overall FPR results, enable the **post_export_metrics/false_positive_rate** checkbox in the left panel and locate the **Overall** value in the table below the bar graph. Similarly, to view FNR results for gender subgroups, enable the **post_export_metrics/false_negative_rate** checkbox in the left panel, and locate the **Overall** value in the table.\n",
@@ -844,7 +906,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "nu8LXMy8nR8N"
+        "id": "nu8LXMy8nR8N",
+        "colab_type": "text"
       },
       "source": [
         "#### **2. What are the FPR\\@0.5 and FNR\\@0.5 for the following gender subgroups:** \n",
@@ -855,7 +918,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "FQGWSdrJy08B"
+        "id": "FQGWSdrJy08B",
+        "colab_type": "text"
       },
       "source": [
         "#### Solution\n",
@@ -866,7 +930,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "Ox0tkciby1qq"
+        "id": "Ox0tkciby1qq",
+        "colab_type": "text"
       },
       "source": [
         "Select a threshold of 0.5 in the dropdown at the the top of the widget. To view FPR results for gender subgroups, enable the **post_export_metrics/false_positive_rate** checkbox in the left panel. To view FNR results for gender subgroups, enable the **post_export_metrics/false_negative_rate** checkbox in the left panel.\n",
@@ -885,7 +950,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "pvIhbl_vnsaE"
+        "id": "pvIhbl_vnsaE",
+        "colab_type": "text"
       },
       "source": [
         "#### **3. What fairness considerations can you identify by comparing aggregate FPR and FNR from #1 above to subgroup FPR and FNR from #2 above?**"
@@ -894,7 +960,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "LlkfgynX0yfF"
+        "id": "LlkfgynX0yfF",
+        "colab_type": "text"
       },
       "source": [
         "#### Solution\n",
@@ -905,7 +972,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "bP9PEk36Br_g"
+        "id": "bP9PEk36Br_g",
+        "colab_type": "text"
       },
       "source": [
         "The **Diff w/ baseline** column in the Fairness Indicators widget tells us the percent difference between a given subgroup's metric performance and the aggregate (overall) metric performance.\n",
@@ -926,6 +994,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "colab_type": "text",
         "id": "0gEH2xBvRzYi"
       },
       "source": [
@@ -939,6 +1008,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "colab_type": "text",
         "id": "rGQGxt8G-p3y"
       },
       "source": [
@@ -948,7 +1018,9 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "9nFGBYRj-erY"
+        "colab_type": "code",
+        "id": "9nFGBYRj-erY",
+        "colab": {}
       },
       "source": [
         "# Limit the number of examples to 1000, so that data loads successfully\n",
@@ -970,12 +1042,13 @@
         "    classifier, FEATURE_MAP).set_label_vocab(['0', '1']).set_target_feature(LABEL)\n",
         "wit = WitWidget(config_builder)"
       ],
-      "execution_count": null,
+      "execution_count": 0,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
+        "colab_type": "text",
         "id": "odeh6SsDUKYq"
       },
       "source": [
@@ -987,7 +1060,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "N8klOQTWMbO5"
+        "id": "N8klOQTWMbO5",
+        "colab_type": "text"
       },
       "source": [
         "#### Task 1\n",
@@ -998,6 +1072,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "colab_type": "text",
         "id": "FBhBsevUOinO"
       },
       "source": [
@@ -1009,6 +1084,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "colab_type": "text",
         "id": "aKbl_6FNOnf1"
       },
       "source": [
@@ -1023,6 +1099,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "colab_type": "text",
         "id": "MaQx5uWJCN3M"
       },
       "source": [
@@ -1036,6 +1113,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "colab_type": "text",
         "id": "cwTzull2U16-"
       },
       "source": [
@@ -1047,6 +1125,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "colab_type": "text",
         "id": "P5MBQR7EF6ny"
       },
       "source": [
@@ -1058,6 +1137,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "colab_type": "text",
         "id": "IXuM7rqXcjTD"
       },
       "source": [
@@ -1072,6 +1152,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "colab_type": "text",
         "id": "19OAoAraVTx6"
       },
       "source": [
@@ -1085,6 +1166,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "colab_type": "text",
         "id": "OaL3qgHCcmwG"
       },
       "source": [
@@ -1096,6 +1178,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "colab_type": "text",
         "id": "R2bZ5_rPcrGW"
       },
       "source": [

--- a/ml/pc/exercises/fairness_text_toxicity_part1.ipynb
+++ b/ml/pc/exercises/fairness_text_toxicity_part1.ipynb
@@ -28,7 +28,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "HnU0fNSuG2aD"
       },
       "source": [
@@ -38,7 +37,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "iVkPBosnIFlu"
       },
       "source": [
@@ -69,7 +67,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "g0PSuIW-I8iP"
       },
       "source": [
@@ -85,27 +82,18 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "2z_xzJ40j9Q-",
-        "colab_type": "code",
-        "colab": {}
+        "id": "2z_xzJ40j9Q-"
       },
       "source": [
-        "!pip install fairness-indicators \\\n",
-        "  \"absl-py==0.8.0\" \\\n",
-        "  \"pyarrow==0.15.1\" \\\n",
-        "  \"apache-beam==2.17.0\" \\\n",
-        "  \"avro-python3==1.9.1\" \\\n",
-        "  \"tfx-bsl==0.21.4\" \\\n",
-        "  \"tensorflow-data-validation==0.21.5\""
+        "!pip install fairness-indicators==0.38.0"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "mdLlKWbIlxYH",
-        "colab_type": "text"
+        "id": "mdLlKWbIlxYH"
       },
       "source": [
         "Next, import all the dependencies we'll use in this exercise, which include Fairness Indicators, TensorFlow Model Analysis (tfma), TensorFlow Data Validation (tfdv), and the What-If tool (WIT):"
@@ -114,9 +102,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab_type": "code",
-        "id": "6E__x2XkJDFW",
-        "colab": {}
+        "id": "6E__x2XkJDFW"
       },
       "source": [
         "%tensorflow_version 2.x\n",
@@ -133,18 +119,17 @@
         "import tensorflow_data_validation as tfdv\n",
         "from tensorflow_model_analysis.addons.fairness.post_export_metrics import fairness_indicators\n",
         "from tensorflow_model_analysis.addons.fairness.view import widget_view\n",
-        "from fairness_indicators.documentation.examples import util\n",
+        "from fairness_indicators.tutorial_utils import util\n",
         "\n",
         "from witwidget.notebook.visualization import WitConfigBuilder\n",
         "from witwidget.notebook.visualization import WitWidget"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "dNfRkjWWIKIs"
       },
       "source": [
@@ -155,8 +140,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "J3R2QWkru1WN",
-        "colab_type": "text"
+        "id": "J3R2QWkru1WN"
       },
       "source": [
         "### About the Civil Comments dataset\n",
@@ -167,8 +151,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "ZZswcJJMCDjU",
-        "colab_type": "text"
+        "id": "ZZswcJJMCDjU"
       },
       "source": [
         "The Civil Comments dataset comprises approximately 2 million public comments that were submitted to the [Civil Comments platform](https://medium.com/@aja_15265/saying-goodbye-to-civil-comments-41859d3a2b1d). [Jigsaw](https://jigsaw.google.com/) sponsored the effort to compile and annotate these comments for ongoing [research](https://arxiv.org/abs/1903.04561); they've also hosted competitions on [Kaggle](https://www.kaggle.com/c/jigsaw-unintended-bias-in-toxicity-classification) to help classify toxic comments as well as minimize unintended model bias. \n",
@@ -248,7 +231,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "0YNqAJW5JjZD"
       },
       "source": [
@@ -262,9 +244,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "duPWGTQAvYKK",
-        "colab_type": "code",
-        "colab": {}
+        "id": "duPWGTQAvYKK"
       },
       "source": [
         "download_original_data = False #@param {type:\"boolean\"}\n",
@@ -287,14 +267,13 @@
         "  validate_tf_file = tf.keras.utils.get_file('validate_tf_processed.tfrecord',\n",
         "                                             'https://storage.googleapis.com/civil_comments_dataset/validate_tf_processed.tfrecord')"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "aLup7wY0_Q3K",
-        "colab_type": "text"
+        "id": "aLup7wY0_Q3K"
       },
       "source": [
         "### Explore the data distribution in TFDV\n",
@@ -307,22 +286,19 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "vkzcE_g8_m_h",
-        "colab_type": "code",
-        "colab": {}
+        "id": "vkzcE_g8_m_h"
       },
       "source": [
         "stats = tfdv.generate_statistics_from_tfrecord(data_location=train_tf_file)\n",
         "tfdv.visualize_statistics(stats)"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "wZU1Djze6E-s",
-        "colab_type": "text"
+        "id": "wZU1Djze6E-s"
       },
       "source": [
         "### Exercise\n",
@@ -332,8 +308,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "ne2_vKAb-XGD",
-        "colab_type": "text"
+        "id": "ne2_vKAb-XGD"
       },
       "source": [
         "#### **1. How many total examples are in the training dataset?**"
@@ -342,8 +317,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "UFBqqnRD-Zkj",
-        "colab_type": "text"
+        "id": "UFBqqnRD-Zkj"
       },
       "source": [
         "#### Solution\n",
@@ -354,8 +328,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "XSkOfchI-arC",
-        "colab_type": "text"
+        "id": "XSkOfchI-arC"
       },
       "source": [
         "**There are 1.08 million total examples in the training dataset.**\n",
@@ -370,8 +343,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "_PgFNm6sAZB2",
-        "colab_type": "text"
+        "id": "_PgFNm6sAZB2"
       },
       "source": [
         "#### **2. How many unique values are there for the `gender` feature? What are they, and what are the frequencies of each of these values?**\n",
@@ -384,8 +356,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "6KmrCS-uAz0s",
-        "colab_type": "text"
+        "id": "6KmrCS-uAz0s"
       },
       "source": [
         "#### Solution\n",
@@ -396,8 +367,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "wkc7P1nvA4cw",
-        "colab_type": "text"
+        "id": "wkc7P1nvA4cw"
       },
       "source": [
         "The **unique** column of the **Categorical Features** table tells us that there are 4 unique values for the `gender` feature.\n",
@@ -415,8 +385,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "NDUO57bdNUQR",
-        "colab_type": "text"
+        "id": "NDUO57bdNUQR"
       },
       "source": [
         "**NOTE:** As described [earlier](#scrollTo=J3R2QWkru1WN), a `gender` feature can contain zero or more of these 4 values, depending on the content of the comment. For example, a comment containing the text \"I am a transgender man\" will have both `transgender` and `male` as `gender` values, whereas a comment that does not reference gender at all will have an empty/false `gender` value."
@@ -425,8 +394,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "wX62Ktwp-qoF",
-        "colab_type": "text"
+        "id": "wX62Ktwp-qoF"
       },
       "source": [
         "#### **3. What percentage of total examples are labeled toxic? Overall, is this a class-balanced dataset (relatively even split of examples between positive and negative classes) or a class-imbalanced dataset (majority of examples are in one class)?**\n",
@@ -437,8 +405,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "IvvxNMgM-6A2",
-        "colab_type": "text"
+        "id": "IvvxNMgM-6A2"
       },
       "source": [
         "#### Solution\n",
@@ -449,8 +416,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "QmCtkzZqOvC2",
-        "colab_type": "text"
+        "id": "QmCtkzZqOvC2"
       },
       "source": [
         "**7.98 percent of examples are toxic.**\n",
@@ -465,8 +431,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "9MGLCsVhGWz0",
-        "colab_type": "text"
+        "id": "9MGLCsVhGWz0"
       },
       "source": [
         "#### **4. Run the following code to analyze label distribution for the subset of examples that contain a `gender` value**"
@@ -475,10 +440,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "f5pEWIkgLTKz",
-        "colab_type": "code",
-        "cellView": "form",
-        "colab": {}
+        "id": "f5pEWIkgLTKz"
       },
       "source": [
         "#@title Calculate label distribution for gender-related examples\n",
@@ -487,12 +449,11 @@
         "toxic_gender_examples = 0\n",
         "nontoxic_gender_examples = 0\n",
         "\n",
-        "# There are 1,082,924 examples in the dataset\n",
-        "for raw_record in raw_dataset.take(1082924):\n",
+        "for raw_record in raw_dataset.take(-1):  # '-1' for \"everything\"\n",
         "  example = tf.train.Example()\n",
         "  example.ParseFromString(raw_record.numpy())\n",
-        "  if str(example.features.feature[\"gender\"].bytes_list.value) != \"[]\":\n",
-        "    if str(example.features.feature[\"toxicity\"].float_list.value) == \"[1.0]\":\n",
+        "  if example.features.feature[\"gender\"].bytes_list.value != []:\n",
+        "    if example.features.feature[\"toxicity\"].float_list.value == [1.0]:\n",
         "      toxic_gender_examples += 1\n",
         "    else:\n",
         "      nontoxic_gender_examples += 1\n",
@@ -500,14 +461,13 @@
         "print(\"Toxic Gender Examples: %s\" % toxic_gender_examples)\n",
         "print(\"Nontoxic Gender Examples: %s\" % nontoxic_gender_examples)"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "WJag4cEKNINy",
-        "colab_type": "text"
+        "id": "WJag4cEKNINy"
       },
       "source": [
         "#### **What percentage of `gender` examples are labeled toxic? Compare this percentage to the percentage of total examples that are labeled toxic from #3 above. What, if any, fairness concerns can you identify based on this comparison?**"
@@ -516,8 +476,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "-J4hbOhgHZid",
-        "colab_type": "text"
+        "id": "-J4hbOhgHZid"
       },
       "source": [
         "#### Solution\n",
@@ -528,8 +487,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "2KK3VWzkHmJ7",
-        "colab_type": "text"
+        "id": "2KK3VWzkHmJ7"
       },
       "source": [
         "There are 7,189 gender-related examples that are labeled toxic, which represent 14.7% of all gender-related examples.\n",
@@ -542,8 +500,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "5WHVYnlGX7g8",
-        "colab_type": "text"
+        "id": "5WHVYnlGX7g8"
       },
       "source": [
         "## Part II: Train the model"
@@ -552,8 +509,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "Xi5nnJ3hX9OO",
-        "colab_type": "text"
+        "id": "Xi5nnJ3hX9OO"
       },
       "source": [
         "In this section, you'll train a classifier on the Civil Comments dataset to predict whether a given text comment is toxic or not."
@@ -562,8 +518,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "ZCYUx0uVAz7v",
-        "colab_type": "text"
+        "id": "ZCYUx0uVAz7v"
       },
       "source": [
         "### Configure model input\n",
@@ -576,9 +531,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "SXqU-HJlB0fG",
-        "colab_type": "code",
-        "colab": {}
+        "id": "SXqU-HJlB0fG"
       },
       "source": [
         "TEXT_FEATURE = 'comment_text'\n",
@@ -598,14 +551,13 @@
         "    'disability':tf.io.VarLenFeature(tf.string),\n",
         "}"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "OlEoDYlvMABU",
-        "colab_type": "text"
+        "id": "OlEoDYlvMABU"
       },
       "source": [
         "The input function below specifies how to preprocess and batch the training data into the model. \n",
@@ -619,9 +571,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "ZaaKKjYwP6XY",
-        "colab_type": "code",
-        "colab": {}
+        "id": "ZaaKKjYwP6XY"
       },
       "source": [
         "def train_input_fn():\n",
@@ -636,13 +586,12 @@
         "      filenames=[train_tf_file]).map(parse_function).batch(512)\n",
         "  return train_dataset"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "EX92OLF2MKSu"
       },
       "source": [
@@ -656,9 +605,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab_type": "code",
-        "id": "2qW8TlgVRzFc",
-        "colab": {}
+        "id": "2qW8TlgVRzFc"
       },
       "source": [
         "BASE_DIR = tempfile.gettempdir()\n",
@@ -681,14 +628,13 @@
         "\n",
         "classifier.train(input_fn=train_input_fn, steps=1000)"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "EjNbZGqFYCUy",
-        "colab_type": "text"
+        "id": "EjNbZGqFYCUy"
       },
       "source": [
         "## Part III: Run Fairness Indicators\n",
@@ -699,8 +645,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "EXd2-UzFbAwE",
-        "colab_type": "text"
+        "id": "EXd2-UzFbAwE"
       },
       "source": [
         "### Export the model"
@@ -709,8 +654,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "jMYWdUaUbIb-",
-        "colab_type": "text"
+        "id": "jMYWdUaUbIb-"
       },
       "source": [
         "First, let's export the model we trained in the [previous section](#scrollTo=5WHVYnlGX7g8), so that we can analyze the results using [TensorFlow Model Analysis (TFMA)](https://www.tensorflow.org/tfx/model_analysis/get_started)."
@@ -719,9 +663,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "R-7dDws2bHxS",
-        "colab_type": "code",
-        "colab": {}
+        "id": "R-7dDws2bHxS"
       },
       "source": [
         "def eval_input_receiver_fn():\n",
@@ -745,14 +687,13 @@
         "  export_dir_base=os.path.join(BASE_DIR, 'tfma_eval_model'),\n",
         "  eval_input_receiver_fn=eval_input_receiver_fn)"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "Xq8NWjzUcAhA",
-        "colab_type": "text"
+        "id": "Xq8NWjzUcAhA"
       },
       "source": [
         "### Compute fairness metrics\n",
@@ -766,9 +707,7 @@
       "cell_type": "code",
       "metadata": {
         "id": "Pkuti2_8cR2D",
-        "colab_type": "code",
-        "cellView": "both",
-        "colab": {}
+        "cellView": "both"
       },
       "source": [
         "tfma_eval_result_path = os.path.join(BASE_DIR, 'tfma_eval_result')\n",
@@ -818,13 +757,12 @@
         "\n",
         "eval_result = tfma.load_eval_result(output_path=tfma_eval_result_path)"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "BssBGpqmwBMd"
       },
       "source": [
@@ -834,21 +772,18 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab_type": "code",
-        "id": "HFlK9U40dyDk",
-        "colab": {}
+        "id": "HFlK9U40dyDk"
       },
       "source": [
         "widget_view.render_fairness_indicator(eval_result=eval_result, slicing_column=slice_selection)"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "wEMcXd8ZO_T4",
-        "colab_type": "text"
+        "id": "wEMcXd8ZO_T4"
       },
       "source": [
         "**NOTE:** The categories above are not mutually exclusive, as examples can be tagged with zero or more of these gender-identity terms. An example with gender values of both `transgender` and `female` will be represented in both the `gender:transgender` and `gender:female` slices."
@@ -857,7 +792,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "R-pA9MSPOl1_"
       },
       "source": [
@@ -875,8 +809,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "YPDRjcKZk3EL",
-        "colab_type": "text"
+        "id": "YPDRjcKZk3EL"
       },
       "source": [
         "#### **1. What are the overall false positive rate (FPR) and false negative rate (FNR) for the model at a classification threshold of 0.5?**"
@@ -885,8 +818,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "tGyACRd8oFwP",
-        "colab_type": "text"
+        "id": "tGyACRd8oFwP"
       },
       "source": [
         "#### Solution\n",
@@ -897,8 +829,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "QzmJGSTYsEYx",
-        "colab_type": "text"
+        "id": "QzmJGSTYsEYx"
       },
       "source": [
         "Select a threshold of 0.5 in the dropdown at the the top of the widget. To view overall FPR results, enable the **post_export_metrics/false_positive_rate** checkbox in the left panel and locate the **Overall** value in the table below the bar graph. Similarly, to view FNR results for gender subgroups, enable the **post_export_metrics/false_negative_rate** checkbox in the left panel, and locate the **Overall** value in the table.\n",
@@ -913,8 +844,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "nu8LXMy8nR8N",
-        "colab_type": "text"
+        "id": "nu8LXMy8nR8N"
       },
       "source": [
         "#### **2. What are the FPR\\@0.5 and FNR\\@0.5 for the following gender subgroups:** \n",
@@ -925,8 +855,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "FQGWSdrJy08B",
-        "colab_type": "text"
+        "id": "FQGWSdrJy08B"
       },
       "source": [
         "#### Solution\n",
@@ -937,8 +866,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "Ox0tkciby1qq",
-        "colab_type": "text"
+        "id": "Ox0tkciby1qq"
       },
       "source": [
         "Select a threshold of 0.5 in the dropdown at the the top of the widget. To view FPR results for gender subgroups, enable the **post_export_metrics/false_positive_rate** checkbox in the left panel. To view FNR results for gender subgroups, enable the **post_export_metrics/false_negative_rate** checkbox in the left panel.\n",
@@ -957,8 +885,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "pvIhbl_vnsaE",
-        "colab_type": "text"
+        "id": "pvIhbl_vnsaE"
       },
       "source": [
         "#### **3. What fairness considerations can you identify by comparing aggregate FPR and FNR from #1 above to subgroup FPR and FNR from #2 above?**"
@@ -967,8 +894,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "LlkfgynX0yfF",
-        "colab_type": "text"
+        "id": "LlkfgynX0yfF"
       },
       "source": [
         "#### Solution\n",
@@ -979,8 +905,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "bP9PEk36Br_g",
-        "colab_type": "text"
+        "id": "bP9PEk36Br_g"
       },
       "source": [
         "The **Diff w/ baseline** column in the Fairness Indicators widget tells us the percent difference between a given subgroup's metric performance and the aggregate (overall) metric performance.\n",
@@ -1001,7 +926,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "0gEH2xBvRzYi"
       },
       "source": [
@@ -1015,7 +939,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "rGQGxt8G-p3y"
       },
       "source": [
@@ -1025,9 +948,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab_type": "code",
-        "id": "9nFGBYRj-erY",
-        "colab": {}
+        "id": "9nFGBYRj-erY"
       },
       "source": [
         "# Limit the number of examples to 1000, so that data loads successfully\n",
@@ -1049,13 +970,12 @@
         "    classifier, FEATURE_MAP).set_label_vocab(['0', '1']).set_target_feature(LABEL)\n",
         "wit = WitWidget(config_builder)"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "odeh6SsDUKYq"
       },
       "source": [
@@ -1067,8 +987,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "N8klOQTWMbO5",
-        "colab_type": "text"
+        "id": "N8klOQTWMbO5"
       },
       "source": [
         "#### Task 1\n",
@@ -1079,7 +998,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "FBhBsevUOinO"
       },
       "source": [
@@ -1091,7 +1009,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "aKbl_6FNOnf1"
       },
       "source": [
@@ -1106,7 +1023,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "MaQx5uWJCN3M"
       },
       "source": [
@@ -1120,7 +1036,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "cwTzull2U16-"
       },
       "source": [
@@ -1132,7 +1047,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "P5MBQR7EF6ny"
       },
       "source": [
@@ -1144,7 +1058,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "IXuM7rqXcjTD"
       },
       "source": [
@@ -1159,7 +1072,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "19OAoAraVTx6"
       },
       "source": [
@@ -1173,7 +1085,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "OaL3qgHCcmwG"
       },
       "source": [
@@ -1185,7 +1096,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "R2bZ5_rPcrGW"
       },
       "source": [


### PR DESCRIPTION
1. Use a modern version of the fairness-indicators, and unpin the other dependencies to match.
2. Fix the `import util` line to match its current location.
3. A few small cosmetic changes.

Note that this is the exact result of exporting the colab to .ipynb. It appears that there are a few cosmetic changes to the output, I'm assuming due to changes in colab. I can revert those if desired.