### PR TITLE
Remove trailing period in test data

### DIFF
--- a/ml/cc/exercises/intro_to_ml_fairness.ipynb
+++ b/ml/cc/exercises/intro_to_ml_fairness.ipynb
@@ -255,7 +255,9 @@
         "                       engine='python', na_values=\"?\")\n",
         "test_df = pd.read_csv(test_csv, names=COLUMNS, sep=r'\\s*,\\s*', skiprows=[0],\n",
         "                      engine='python', na_values=\"?\")\n",
-        "test_df.replace(to_replace=\"50K\\.\", value=\"50K\", regex=True, inplace=True)"
+        "# Strip trailing periods mistakenly included only in UCI test dataset.\n",
+        "test_df['income_bracket'] = test_df.income_bracket.str.rstrip('.')"
+
 
       ],
       "execution_count": 0,

--- a/ml/cc/exercises/intro_to_ml_fairness.ipynb
+++ b/ml/cc/exercises/intro_to_ml_fairness.ipynb
@@ -254,7 +254,9 @@
         "train_df = pd.read_csv(train_csv, names=COLUMNS, sep=r'\\s*,\\s*', \n",
         "                       engine='python', na_values=\"?\")\n",
         "test_df = pd.read_csv(test_csv, names=COLUMNS, sep=r'\\s*,\\s*', skiprows=[0],\n",
-        "                      engine='python', na_values=\"?\")"
+        "                      engine='python', na_values=\"?\")\n",
+        "test_df.replace(to_replace=\"50K\\.\", value=\"50K\", regex=True, inplace=True)"
+
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
I ran the code as given in this notebook and got a confusion matrix like this:

![confusion_matrix_before](https://user-images.githubusercontent.com/53238192/165835124-88b57f27-4e2b-48ad-8ddb-d2f815cbc37a.png)

It turns out the income bracket data in the test CSV file ( https://download.mlcc.google.com/mledu-datasets/adult_census_test.csv ) is in the format ">50K." and <=50K." (with trailing periods), so checking for equality to ">50K" always returns False. 

![training_and_test_csvs](https://user-images.githubusercontent.com/53238192/165835553-e1418f6a-10f4-4931-b0b9-26ea6bf0882c.png)

I added a line to remove the trailing period in the test dataset, and got more reasonable results. This is probably more of a workaround as opposed to standardizing the actual CSV files (unless the trailing period is intentional), but it got the examples to work.

![confusion_matrix_after](https://user-images.githubusercontent.com/53238192/165835808-aa4354dc-6efd-44cc-9159-3976d02039b5.png)

