### PR TITLE
Fix typo in Linear Regression example

### DIFF
--- a/ml/cc/exercises/linear_regression_with_a_real_dataset.ipynb
+++ b/ml/cc/exercises/linear_regression_with_a_real_dataset.ipynb
@@ -155,7 +155,7 @@
         "\n",
         "Datasets are often stored on disk or at a URL in [.csv format](https://wikipedia.org/wiki/Comma-separated_values). \n",
         "\n",
-        "A well-formed .csv file contains column names in the first row, followed by many rows of data.  A comma divides each value in each row. For example, here are the first five rows of the .csv file file holding the California Housing Dataset:\n",
+        "A well-formed .csv file contains column names in the first row, followed by many rows of data.  A comma divides each value in each row. For example, here are the first five rows of the .csv file holding the California Housing Dataset:\n",
         "\n",
         "```\n",
         "\"longitude\",\"latitude\",\"housing_median_age\",\"total_rooms\",\"total_bedrooms\",\"population\",\"households\",\"median_income\",\"median_house_value\"\n",


### PR DESCRIPTION
I noticed a typo in one of the examples while working through it. Please let me know if any further action besides changing the individual line is necessary.