### PR TITLE
Update fairness indicators version to 0.40.0

### DIFF
--- a/ml/pc/exercises/fairness_text_toxicity_part1.ipynb
+++ b/ml/pc/exercises/fairness_text_toxicity_part1.ipynb
@@ -90,7 +90,7 @@
         "colab": {}
       },
       "source": [
-         "!pip install fairness-indicators==0.38.0"
+         "!pip install fairness-indicators==0.40.0"
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
Update fairness indicators version to 0.40.0 to solve type mismatch between TFDV and apache beam.