### PR TITLE
Fix x-axis upper limit in model plotting function in linear_regression_with_a_real_dataset

### DIFF
--- a/ml/cc/exercises/linear_regression_with_a_real_dataset.ipynb
+++ b/ml/cc/exercises/linear_regression_with_a_real_dataset.ipynb
@@ -397,7 +397,7 @@
         "  # at coordinates (x0, y0) and ends at coordinates (x1, y1).\n",
         "  x0 = 0\n",
         "  y0 = trained_bias\n",
-        "  x1 = 10000\n",
+        "  x1 = random_examples[feature].max()\n",
         "  y1 = trained_bias + (trained_weight * x1)\n",
         "  plt.plot([x0, x1], [y0, y1], c='r')\n",
         "\n",


### PR DESCRIPTION
The `x1` limit was previously set to 10000, but this doesn't work for features with narrower ranges like `median_income`, which has a max value of 15. I changed it to make it depend on the random example's maximum value for that feature.