### PR TITLE
Fix urls

### DIFF
--- a/ml/cc/exercises/binary_classification.ipynb
+++ b/ml/cc/exercises/binary_classification.ipynb
@@ -369,7 +369,7 @@
         "    topography.\n",
         "  * `train_model(model, dataset, epochs, label_name, batch_size, shuffle)`, uses input features and labels to train the model.\n",
         "\n",
-        "Prior exercises used [ReLU](https://developers.google.com/machine-learning/glossary#ReLU) as the [activation function](https://developers.google.com/machine-learning/glossary#activation_function). By contrast, this exercise uses [sigmoid](https://developers.google.com/machine-learning/glossary#sigmoid_function) as the activation function. "
+        "Prior exercises used [ReLU](https://developers.google.com/machine-learning/glossary#ReLU) as the [activation function](https://developers.google.com/machine-learning/glossary#activation-function). By contrast, this exercise uses [sigmoid](https://developers.google.com/machine-learning/glossary#sigmoid-function) as the activation function. "
       ]
     },
     {


### PR DESCRIPTION
glossary seems to use - instead of _ for spaces in header anchors.