### PR TITLE
Trained weight needs to be a scalar to run the plotting functions later

### DIFF
--- a/ml/cc/exercises/linear_regression_with_a_real_dataset.ipynb
+++ b/ml/cc/exercises/linear_regression_with_a_real_dataset.ipynb
@@ -335,7 +335,7 @@
         "                      epochs=epochs)\n",
         "\n",
         "  # Gather the trained model's weight and bias.\n",
-        "  trained_weight = model.get_weights()[0]\n",
+        "  trained_weight = model.get_weights()[0][0]\n",
         "  trained_bias = model.get_weights()[1]\n",
         "\n",
         "  # The list of epochs is stored separately from the rest of history.\n",

--- a/ml/cc/exercises/linear_regression_with_synthetic_data.ipynb
+++ b/ml/cc/exercises/linear_regression_with_synthetic_data.ipynb
@@ -148,7 +148,7 @@
         "                      epochs=epochs)\n",
         "\n",
         "  # Gather the trained model's weight and bias.\n",
-        "  trained_weight = model.get_weights()[0]\n",
+        "  trained_weight = model.get_weights()[0][0]\n",
         "  trained_bias = model.get_weights()[1]\n",
         "\n",
         "  # The list of epochs is stored separately from the \n",


### PR DESCRIPTION
Trained weight needs to be a scalar to run the plotting functions later. So reducing only to the first element of the one-item array.

## Before
![No_trained_weights_zero_index](https://github.com/google/eng-edu/assets/529304/bce2aef1-1764-4065-8192-3e9d9e97df45)
## After
![Trained_weights_with_zero_index](https://github.com/google/eng-edu/assets/529304/b69cb2cb-4ffd-47cf-8dc8-bbdf4ff5c495)
