### PR TITLE
Update numpy_ultraquick_tutorial.ipynb

### DIFF
--- a/ml/cc/exercises/numpy_ultraquick_tutorial.ipynb
+++ b/ml/cc/exercises/numpy_ultraquick_tutorial.ipynb
@@ -346,7 +346,7 @@
       "source": [
         "#@title Double-click to see a possible solution to Task 2.\n",
         "\n",
-        "noise = (np.random.random([15]) * 4) - 2\n",
+        "noise = (np.random.random([14]) * 4) - 2\n",
         "print(noise)\n",
         "label = label + noise \n",
         "print(label)"


### PR DESCRIPTION
Updated Double-click to see a possible solution to Task 2 to noise = (np.random.random[14] * 4) - 2
removes error "operands could not be broadcast together with shapes (14,) (15,)" when running code