### PR TITLE
Fix: Update lr to learning_rate in RMSprop optimizer parameter

### DIFF
--- a/ml/pc/exercises/image_classification_part1.ipynb
+++ b/ml/pc/exercises/image_classification_part1.ipynb
@@ -438,7 +438,7 @@
         "from tensorflow.keras.optimizers import RMSprop\n",
         "\n",
         "model.compile(loss='binary_crossentropy',\n",
-        "              optimizer=RMSprop(lr=0.001),\n",
+        "              optimizer=RMSprop(learning_rate=0.001),\n",
         "              metrics=['acc'])"
       ]
     },


### PR DESCRIPTION
The lr argument is not recognized by the RMSprop optimizer. In the current version of Keras, the learning rate argument for the RMSprop optimizer is learning_rate. Changing' lr' to' learning_rate' will resolve the issue.

Scope: image_classification_part1.ipynb file