### PR TITLE
Fix: Update model.fit_generator to model.fit

### DIFF
--- a/ml/pc/exercises/image_classification_part1.ipynb
+++ b/ml/pc/exercises/image_classification_part1.ipynb
@@ -511,7 +511,7 @@
       },
       "outputs": [],
       "source": [
-        "history = model.fit_generator(\n",
+        "history = model.fit(\n",
         "      train_generator,\n",
         "      steps_per_epoch=100,  # 2000 images = batch_size * steps\n",
         "      epochs=15,\n",


### PR DESCRIPTION
The method 'fit_generator' has been deprecated in recent versions of TensorFlow/Keras. The recommended method for training a model with a data generator is now 'fit'.

Update the code to use 'model.fit' instead of 'model.fit_generator'.

Scope: image_classification_part1.ipynb file